### PR TITLE
REST-server embedded in the desktop application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/
 .classpath
 .project
 .settings/
+*.sqlite
+qabel-desktop.iml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+hello:
+	java -Djava.library.path=../qabel-core -cp "../qabel-helloworld-module/build/libs/qabel-helloworld-module-0.1.jar:build/libs/qabel-desktop-0.1.jar" de.qabel.desktop.QblMain -module qabel-helloworld-module/build/libs/qabel-helloworld-module-0.1.jar:de.qabel.helloworld.QblHelloWorldModule
+
+file:
+	java -Djava.library.path=../qabel-core -cp "../qabel-file-module/build/libs/qabel-file-module-0.1.jar:build/libs/qabel-desktop-0.1.jar" de.qabel.desktop.QblMain -module qabel-file-module/build/libs/qabel-file-module-0.1.jar:de.qabel.filesync.QblFileSyncModule
+
+

--- a/README.md
+++ b/README.md
@@ -21,4 +21,6 @@ Desktop Frontend of Qabel
 
    ```
    java -Djava.library.path=../qabel-core -cp "../qabel-helloworld-module/build/libs/qabel-helloworld-module-0.1.jar:../qabel-desktop/build/libs/qabel-desktop-0.1.jar" de.qabel.desktop.QblMain -module qabel-helloworld-module/build/libs/qabel-helloworld-module-0.1.jar:de.qabel.helloworld.QblHelloWorldModule
+
+0. an HTTP server will start at port 9696
    ```

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ classes {
     }
 }
 
+tasks.withType(Test) {
+	systemProperty "java.library.path", "../qabel-core"
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '2.2.1'
 }

--- a/src/main/java/de/qabel/desktop/QblMain.java
+++ b/src/main/java/de/qabel/desktop/QblMain.java
@@ -30,6 +30,8 @@ public class QblMain {
 
 	private DropActor dropActor;
 	private Thread resourceActorThread;
+	private QblRESTServer restServer;
+
 	public static void main(String[] args) throws InstantiationException,
 			IllegalAccessException, ClassNotFoundException,
 			InterruptedException, URISyntaxException, QblDropInvalidURL, InvalidKeyException, IOException {
@@ -140,8 +142,8 @@ public class QblMain {
 		dropActorThread = new Thread(dropActor, "DropActor");
 		dropActorThread.start();
 		moduleManager = new ModuleManager(emitter, resourceActor);
-		Thread restServer = new Thread(new QblRESTServer(9696, resourceActor, dropActor, moduleManager));
-		restServer.start();
+		restServer = new QblRESTServer(9696, resourceActor, dropActor, moduleManager);
+		restServer.run();
 		System.out.println("REST Server running at http://localhost:9696");
 	}
 

--- a/src/main/java/de/qabel/desktop/QblMain.java
+++ b/src/main/java/de/qabel/desktop/QblMain.java
@@ -39,6 +39,10 @@ public class QblMain {
 		main.loadDropServers();
 		main.loadContactsAndIdentities();
 		main.startModules();
+
+		Thread restServer = new Thread(new QblRESTServer(9696));
+		restServer.start();
+		System.out.println("REST Server running at http://localhost:9696");
 		main.run();
 	}
 

--- a/src/main/java/de/qabel/desktop/QblMain.java
+++ b/src/main/java/de/qabel/desktop/QblMain.java
@@ -1,6 +1,7 @@
 package de.qabel.desktop;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
@@ -31,7 +32,7 @@ public class QblMain {
 	private Thread resourceActorThread;
 	public static void main(String[] args) throws InstantiationException,
 			IllegalAccessException, ClassNotFoundException,
-			InterruptedException, URISyntaxException, QblDropInvalidURL, InvalidKeyException {
+			InterruptedException, URISyntaxException, QblDropInvalidURL, InvalidKeyException, IOException {
 
 		QblMain main = new QblMain();
 		main.parse(args);
@@ -122,7 +123,7 @@ public class QblMain {
     /**
      * Instantiates global DropController and ModuleManager.
      */
-	private QblMain() {
+	private QblMain() throws IOException {
 		Persistence<String> persistence = null;
 		try {
 			persistence = new SQLitePersistence("qabel-desktop.sqlite", "qabel".toCharArray());

--- a/src/main/java/de/qabel/desktop/QblMain.java
+++ b/src/main/java/de/qabel/desktop/QblMain.java
@@ -1,7 +1,6 @@
 package de.qabel.desktop;
 
 import java.io.File;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
@@ -40,9 +39,6 @@ public class QblMain {
 		main.loadContactsAndIdentities();
 		main.startModules();
 
-		Thread restServer = new Thread(new QblRESTServer(9696));
-		restServer.start();
-		System.out.println("REST Server running at http://localhost:9696");
 		main.run();
 	}
 
@@ -143,6 +139,9 @@ public class QblMain {
 		dropActorThread = new Thread(dropActor, "DropActor");
 		dropActorThread.start();
 		moduleManager = new ModuleManager(emitter, resourceActor);
+		Thread restServer = new Thread(new QblRESTServer(9696, resourceActor, dropActor, moduleManager));
+		restServer.start();
+		System.out.println("REST Server running at http://localhost:9696");
 	}
 
     /**

--- a/src/main/java/de/qabel/desktop/QblRESTServer.java
+++ b/src/main/java/de/qabel/desktop/QblRESTServer.java
@@ -1,0 +1,41 @@
+package de.qabel.desktop;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+class QblRESTServer implements Runnable {
+
+    private int port;
+
+    public QblRESTServer(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public void run() {
+        HttpServer server = null;
+        try {
+            server = HttpServer.create(new InetSocketAddress(this.port), 0);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        server.setExecutor(null);
+        server.createContext("/", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange httpExchange) throws IOException {
+                String response = "Response";
+                httpExchange.sendResponseHeaders(200, response.length());
+                OutputStream os = httpExchange.getResponseBody();
+                os.write(response.getBytes());
+                os.close();
+            }
+        });
+        server.start();
+
+    }
+}

--- a/src/main/java/de/qabel/desktop/QblRESTServer.java
+++ b/src/main/java/de/qabel/desktop/QblRESTServer.java
@@ -1,18 +1,40 @@
 package de.qabel.desktop;
 
+import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-
 import de.qabel.core.config.ResourceActor;
 import de.qabel.core.drop.DropActor;
 import de.qabel.core.module.ModuleManager;
 
-public class QblRESTServer implements Runnable {
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class QblRESTServer implements Runnable {    private static final String HOSTNAME = "localhost";
+
+    private static final String HEADER_ALLOW = "Allow";
+    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+
+    private static final Charset CHARSET = StandardCharsets.UTF_8;
+
+    private static final int STATUS_OK = 200;
+    private static final int STATUS_METHOD_NOT_ALLOWED = 405;
+
+    private static final int NO_RESPONSE_LENGTH = -1;
+
+    private static final String METHOD_GET = "GET";
+    private static final String METHOD_OPTIONS = "OPTIONS";
+    private static final String ALLOWED_METHODS = METHOD_GET + "," + METHOD_OPTIONS;
 
     private int port;
 
@@ -48,6 +70,41 @@ public class QblRESTServer implements Runnable {
         this.moduleManager = moduleManager;
     }
 
+    /**
+     * Base clase for REST handlers
+     */
+    abstract class SimpleHandler implements HttpHandler {
+
+        private Map<String, List<String>> requestParameters;
+        private Headers headers;
+        private String requestMethod;
+
+        @Override
+        public void handle(HttpExchange he) throws IOException {
+
+
+            try {
+                headers = he.getResponseHeaders();
+                requestMethod = he.getRequestMethod().toUpperCase();
+                requestParameters = getRequestParameters(he.getRequestURI());
+                headers.set(HEADER_CONTENT_TYPE, String.format("application/json; charset=%s", CHARSET));
+                switch (requestMethod) {
+                    case METHOD_GET:
+                        get(he);
+                        break;
+                    default:
+                        headers.set(HEADER_ALLOW, ALLOWED_METHODS);
+                        he.sendResponseHeaders(STATUS_METHOD_NOT_ALLOWED, NO_RESPONSE_LENGTH);
+                        break;
+                }
+            } finally {
+                he.close();
+            }
+        }
+
+        public abstract void get(HttpExchange he) throws IOException;
+    }
+
     @Override
     public void run() {
         server = null;
@@ -57,16 +114,15 @@ public class QblRESTServer implements Runnable {
             e.printStackTrace();
         }
         server.setExecutor(null);
-        server.createContext("/", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange httpExchange) throws IOException {
-                String response = "Response";
-                httpExchange.sendResponseHeaders(200, response.length());
-                OutputStream os = httpExchange.getResponseBody();
-                os.write(response.getBytes());
-                os.close();
-            }
-        });
+        server.createContext("/status", new SimpleHandler() {
+                    @Override
+                    public void get(HttpExchange he) throws IOException {
+                        final String responseBody = "{status: \"running\"}";
+                        final byte[] rawResponseBody = responseBody.getBytes(CHARSET);
+                        he.sendResponseHeaders(STATUS_OK, rawResponseBody.length);
+                        he.getResponseBody().write(rawResponseBody);
+                    }
+                });
         server.start();
 
     }
@@ -77,4 +133,45 @@ public class QblRESTServer implements Runnable {
             server.stop(0);
         }
     }
+
+    /**
+     * Extract request parameter from a URL.
+     * @param requestUri
+     * @return Map of parameters
+     * @throws UnsupportedEncodingException
+     */
+    private static Map<String, List<String>> getRequestParameters(final URI requestUri) throws UnsupportedEncodingException {
+        final Map<String, List<String>> requestParameters = new LinkedHashMap<>();
+        final String requestQuery = requestUri.getRawQuery();
+        if (requestQuery != null) {
+            final String[] rawRequestParameters = requestQuery.split("[&;]", -1);
+            for (final String rawRequestParameter : rawRequestParameters) {
+                final String[] requestParameter = rawRequestParameter.split("=", 2);
+                final String requestParameterName = decodeUrlComponent(requestParameter[0]);
+                if (!requestParameters.containsKey(requestParameterName)) {
+                    requestParameters.put(requestParameterName, new ArrayList<String>());
+                }
+                final String requestParameterValue = requestParameter.length > 1 ? decodeUrlComponent(requestParameter[1]) : null;
+                requestParameters.get(requestParameterName).add(requestParameterValue);
+            }
+        }
+        return requestParameters;
+    }
+
+    /**
+     * Decode a url component
+     * Always uses the constant CHARSET.
+     * @param urlComponent
+     * @return decoded url compoment
+     * @throws UnsupportedEncodingException
+     */
+    private static String decodeUrlComponent(final String urlComponent) {
+        try {
+            return URLDecoder.decode(urlComponent, CHARSET.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new InternalError(CHARSET + " is not a supported encoding");
+        }
+    }
+
+
 }

--- a/src/main/java/de/qabel/desktop/QblRESTServer.java
+++ b/src/main/java/de/qabel/desktop/QblRESTServer.java
@@ -8,17 +8,49 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 
-class QblRESTServer implements Runnable {
+import de.qabel.core.config.ResourceActor;
+import de.qabel.core.drop.DropActor;
+import de.qabel.core.module.ModuleManager;
+
+public class QblRESTServer implements Runnable {
 
     private int port;
 
-    public QblRESTServer(int port) {
+    public ResourceActor getResourceActor() {
+        return resourceActor;
+    }
+
+    public DropActor getDropActor() {
+        return dropActor;
+    }
+
+    public ModuleManager getModuleManager() {
+        return moduleManager;
+    }
+
+    public HttpServer getServer() {
+        return server;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    private ResourceActor resourceActor;
+    private DropActor dropActor;
+    private ModuleManager moduleManager;
+    private HttpServer server;
+
+    public QblRESTServer(int port, ResourceActor resourceActor, DropActor dropActor, ModuleManager moduleManager) {
         this.port = port;
+        this.resourceActor = resourceActor;
+        this.dropActor = dropActor;
+        this.moduleManager = moduleManager;
     }
 
     @Override
     public void run() {
-        HttpServer server = null;
+        server = null;
         try {
             server = HttpServer.create(new InetSocketAddress(this.port), 0);
         } catch (IOException e) {
@@ -37,5 +69,12 @@ class QblRESTServer implements Runnable {
         });
         server.start();
 
+    }
+
+    public void stop() {
+        if (server != null) {
+            // delay until stopping = 0
+            server.stop(0);
+        }
     }
 }

--- a/src/main/java/de/qabel/desktop/QblRESTServer.java
+++ b/src/main/java/de/qabel/desktop/QblRESTServer.java
@@ -20,158 +20,146 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public class QblRESTServer implements Runnable {    private static final String HOSTNAME = "localhost";
+/**
+ * HTTP Server that starts itself in a background thread and serves as a REST-server for the
+ * desktop application. It is an interface for external programs, for example user interfaces
+ * which should be decoupled from the qabel-core.
+ */
+public class QblRESTServer {
 
-    private static final String HEADER_ALLOW = "Allow";
-    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+	private static final String HEADER_ALLOW = "Allow";
+	private static final String HEADER_CONTENT_TYPE = "Content-Type";
 
-    private static final Charset CHARSET = StandardCharsets.UTF_8;
+	private static final Charset CHARSET = StandardCharsets.UTF_8;
 
-    private static final int STATUS_OK = 200;
-    private static final int STATUS_METHOD_NOT_ALLOWED = 405;
+	private static final int STATUS_OK = 200;
+	private static final int STATUS_METHOD_NOT_ALLOWED = 405;
 
-    private static final int NO_RESPONSE_LENGTH = -1;
+	private static final int NO_RESPONSE_LENGTH = -1;
 
-    private static final String METHOD_GET = "GET";
-    private static final String METHOD_OPTIONS = "OPTIONS";
-    private static final String ALLOWED_METHODS = METHOD_GET + "," + METHOD_OPTIONS;
+	private static final String METHOD_GET = "GET";
+	private static final String METHOD_OPTIONS = "OPTIONS";
+	private static final String ALLOWED_METHODS = METHOD_GET + "," + METHOD_OPTIONS;
 
-    private int port;
+	private ResourceActor resourceActor;
+	private DropActor dropActor;
+	private ModuleManager moduleManager;
+	private HttpServer server;
 
-    public ResourceActor getResourceActor() {
-        return resourceActor;
-    }
+	private int port;
 
-    public DropActor getDropActor() {
-        return dropActor;
-    }
-
-    public ModuleManager getModuleManager() {
-        return moduleManager;
-    }
-
-    public HttpServer getServer() {
-        return server;
-    }
-
-    public int getPort() {
-        return port;
-    }
-
-    private ResourceActor resourceActor;
-    private DropActor dropActor;
-    private ModuleManager moduleManager;
-    private HttpServer server;
-
-    public QblRESTServer(int port, ResourceActor resourceActor, DropActor dropActor, ModuleManager moduleManager) {
-        this.port = port;
-        this.resourceActor = resourceActor;
-        this.dropActor = dropActor;
-        this.moduleManager = moduleManager;
-    }
-
-    /**
-     * Base clase for REST handlers
-     */
-    abstract class SimpleHandler implements HttpHandler {
-
-        private Map<String, List<String>> requestParameters;
-        private Headers headers;
-        private String requestMethod;
-
-        @Override
-        public void handle(HttpExchange he) throws IOException {
+	public QblRESTServer(int port, ResourceActor resourceActor, DropActor dropActor, ModuleManager moduleManager) throws IOException {
+		this.port = port;
+		this.resourceActor = resourceActor;
+		this.dropActor = dropActor;
+		this.moduleManager = moduleManager;
+		server = HttpServer.create(new InetSocketAddress(this.port), 0);
+		server.setExecutor(null);
+	}
 
 
-            try {
-                headers = he.getResponseHeaders();
-                requestMethod = he.getRequestMethod().toUpperCase();
-                requestParameters = getRequestParameters(he.getRequestURI());
-                headers.set(HEADER_CONTENT_TYPE, String.format("application/json; charset=%s", CHARSET));
-                switch (requestMethod) {
-                    case METHOD_GET:
-                        get(he);
-                        break;
-                    default:
-                        headers.set(HEADER_ALLOW, ALLOWED_METHODS);
-                        he.sendResponseHeaders(STATUS_METHOD_NOT_ALLOWED, NO_RESPONSE_LENGTH);
-                        break;
-                }
-            } finally {
-                he.close();
-            }
-        }
+	public void run() {
+		setupHandlers();
+		server.start();
 
-        public abstract void get(HttpExchange he) throws IOException;
-    }
+	}
 
-    @Override
-    public void run() {
-        server = null;
-        try {
-            server = HttpServer.create(new InetSocketAddress(this.port), 0);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        server.setExecutor(null);
-        server.createContext("/status", new SimpleHandler() {
-                    @Override
-                    public void get(HttpExchange he) throws IOException {
-                        final String responseBody = "{status: \"running\"}";
-                        final byte[] rawResponseBody = responseBody.getBytes(CHARSET);
-                        he.sendResponseHeaders(STATUS_OK, rawResponseBody.length);
-                        he.getResponseBody().write(rawResponseBody);
-                    }
-                });
-        server.start();
+	private void setupHandlers() {
+		server.createContext("/status", new SimpleHandler() {
+			@Override
+			public void get(HttpExchange he) throws IOException {
+				final String responseBody = "{status: \"running\"}";
+				final byte[] rawResponseBody = responseBody.getBytes(CHARSET);
+				he.sendResponseHeaders(STATUS_OK, rawResponseBody.length);
+				he.getResponseBody().write(rawResponseBody);
+			}
+		});
+	}
 
-    }
+	/**
+	 * Stop HttpServer
+	 */
+	public void stop() {
+		if (server != null) {
+			// delay until stopping = 0
+			server.stop(0);
+		}
+	}
 
-    public void stop() {
-        if (server != null) {
-            // delay until stopping = 0
-            server.stop(0);
-        }
-    }
+	/**
+	 * Extract request parameter from a URL.
+	 *
+	 * @param requestUri
+	 * @return Map of parameters
+	 * @throws UnsupportedEncodingException
+	 */
+	private static Map<String, List<String>> getRequestParameters(final URI requestUri) throws UnsupportedEncodingException {
+		final Map<String, List<String>> requestParameters = new LinkedHashMap<>();
+		final String requestQuery = requestUri.getRawQuery();
+		if (requestQuery != null) {
+			final String[] rawRequestParameters = requestQuery.split("[&;]", -1);
+			for (final String rawRequestParameter : rawRequestParameters) {
+				final String[] requestParameter = rawRequestParameter.split("=", 2);
+				final String requestParameterName = decodeUrlComponent(requestParameter[0]);
+				if (!requestParameters.containsKey(requestParameterName)) {
+					requestParameters.put(requestParameterName, new ArrayList<String>());
+				}
+				final String requestParameterValue = requestParameter.length > 1 ? decodeUrlComponent(requestParameter[1]) : null;
+				requestParameters.get(requestParameterName).add(requestParameterValue);
+			}
+		}
+		return requestParameters;
+	}
 
-    /**
-     * Extract request parameter from a URL.
-     * @param requestUri
-     * @return Map of parameters
-     * @throws UnsupportedEncodingException
-     */
-    private static Map<String, List<String>> getRequestParameters(final URI requestUri) throws UnsupportedEncodingException {
-        final Map<String, List<String>> requestParameters = new LinkedHashMap<>();
-        final String requestQuery = requestUri.getRawQuery();
-        if (requestQuery != null) {
-            final String[] rawRequestParameters = requestQuery.split("[&;]", -1);
-            for (final String rawRequestParameter : rawRequestParameters) {
-                final String[] requestParameter = rawRequestParameter.split("=", 2);
-                final String requestParameterName = decodeUrlComponent(requestParameter[0]);
-                if (!requestParameters.containsKey(requestParameterName)) {
-                    requestParameters.put(requestParameterName, new ArrayList<String>());
-                }
-                final String requestParameterValue = requestParameter.length > 1 ? decodeUrlComponent(requestParameter[1]) : null;
-                requestParameters.get(requestParameterName).add(requestParameterValue);
-            }
-        }
-        return requestParameters;
-    }
+	/**
+	 * Decode a url component
+	 * Always uses the constant CHARSET.
+	 *
+	 * @param urlComponent
+	 * @return decoded url compoment
+	 * @throws UnsupportedEncodingException
+	 */
+	private static String decodeUrlComponent(final String urlComponent) {
+		try {
+			return URLDecoder.decode(urlComponent, CHARSET.name());
+		} catch (UnsupportedEncodingException e) {
+			throw new InternalError(CHARSET + " is not a supported encoding");
+		}
+	}
 
-    /**
-     * Decode a url component
-     * Always uses the constant CHARSET.
-     * @param urlComponent
-     * @return decoded url compoment
-     * @throws UnsupportedEncodingException
-     */
-    private static String decodeUrlComponent(final String urlComponent) {
-        try {
-            return URLDecoder.decode(urlComponent, CHARSET.name());
-        } catch (UnsupportedEncodingException e) {
-            throw new InternalError(CHARSET + " is not a supported encoding");
-        }
-    }
+	/**
+	 * Base clase for REST handlers
+	 */
+	abstract class SimpleHandler implements HttpHandler {
 
+		private Map<String, List<String>> requestParameters;
+		private Headers headers;
+		private String requestMethod;
+
+		@Override
+		public void handle(HttpExchange he) throws IOException {
+
+
+			try {
+				headers = he.getResponseHeaders();
+				requestMethod = he.getRequestMethod().toUpperCase();
+				requestParameters = getRequestParameters(he.getRequestURI());
+				headers.set(HEADER_CONTENT_TYPE, String.format("application/json; charset=%s", CHARSET));
+				switch (requestMethod) {
+					case METHOD_GET:
+						get(he);
+						break;
+					default:
+						headers.set(HEADER_ALLOW, ALLOWED_METHODS);
+						he.sendResponseHeaders(STATUS_METHOD_NOT_ALLOWED, NO_RESPONSE_LENGTH);
+						break;
+				}
+			} finally {
+				he.close();
+			}
+		}
+
+		public abstract void get(HttpExchange he) throws IOException;
+	}
 
 }

--- a/src/test/java/de/qabel/desktop/QblRESTServerTest.java
+++ b/src/test/java/de/qabel/desktop/QblRESTServerTest.java
@@ -1,31 +1,24 @@
 package de.qabel.desktop;
 
-import com.sun.net.httpserver.HttpServer;
 import de.qabel.ackack.event.EventEmitter;
 import de.qabel.core.config.*;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.drop.DropActor;
 import de.qabel.core.drop.DropURL;
 import de.qabel.core.module.ModuleManager;
-import de.qabel.desktop.QblRESTServer;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Assert;
-
-import java.io.File;
-import java.net.ProtocolException;
-import java.util.ArrayList;
-import java.util.Collection;
+import org.junit.Before;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
-/**
- * Created by dax on 24.09.15.
- */
+import java.util.ArrayList;
+import java.util.Collection;
+
 public class QblRESTServerTest {
 
 	private static final String DB_NAME = "QblHelloWorldModuleTest.sqlite";
@@ -42,6 +35,7 @@ public class QblRESTServerTest {
 		Persistence<String> persistence = new SQLitePersistence(DB_NAME, "qabel".toCharArray());
 		resourceActor = new ResourceActor(persistence, EventEmitter.getDefault());
 		moduleManager = new ModuleManager(EventEmitter.getDefault(), resourceActor);
+		restServer = new QblRESTServer(PORT, resourceActor, dropActor,moduleManager);
 
 		Collection<DropURL> bobDropURLs = new ArrayList<>();
 		bobDropURLs.add(new DropURL(BOB_DROP_URL));
@@ -63,15 +57,11 @@ public class QblRESTServerTest {
 		Thread dropActorThread = new Thread(dropActor);
 		dropActor.setInterval(500);
 		dropActorThread.start();
-
-		restServer = new QblRESTServer(PORT, resourceActor, dropActor,moduleManager);
 	}
 
 	@After
 	public void tearDown() throws InterruptedException {
-		if (restServer != null) {
-			restServer.stop();
-		}
+		restServer.stop();
 		File persistenceTestDB = new File(DB_NAME);
 		if(persistenceTestDB.exists()) {
 			persistenceTestDB.delete();
@@ -90,7 +80,6 @@ public class QblRESTServerTest {
 
         StringBuffer output = new StringBuffer();
         String out;
-        System.out.println("Output from Server .... \n");
         while ((out = br.readLine()) != null) {
             output.append(out);
         }
@@ -102,16 +91,9 @@ public class QblRESTServerTest {
 
 	@org.junit.Test
     public void testSetUp() throws Exception {
-		Assert.assertEquals(PORT, restServer.getPort());
-		Assert.assertEquals(dropActor, restServer.getDropActor());
-		Assert.assertEquals(moduleManager, restServer.getModuleManager());
-		Assert.assertEquals(resourceActor, restServer.getResourceActor());
-		Assert.assertNull(restServer.getServer());
 		restServer.run();
-		Assert.assertNotNull(restServer.getServer());
 		Assert.assertEquals(200, sendRequest("status", "GET"));
 		Assert.assertEquals("{status: \"running\"}", requestOutput);
 	}
-
 
 }

--- a/src/test/java/de/qabel/desktop/QblRESTServerTest.java
+++ b/src/test/java/de/qabel/desktop/QblRESTServerTest.java
@@ -13,9 +13,16 @@ import org.junit.Before;
 import org.junit.Assert;
 
 import java.io.File;
+import java.net.ProtocolException;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
 /**
  * Created by dax on 24.09.15.
  */
@@ -28,6 +35,7 @@ public class QblRESTServerTest {
 	private QblRESTServer restServer;
 	private DropActor dropActor;
 	private ResourceActor resourceActor;
+	private String requestOutput;
 
 	@Before
 	public void setUp() throws Exception {
@@ -70,6 +78,28 @@ public class QblRESTServerTest {
 		}
 	}
 
+	private int sendRequest(String ressource, String method) throws IOException {
+		String address = "http://localhost:" + PORT + "/" + ressource;
+        URL url = new URL(address);
+		HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+		conn.setRequestMethod(method);
+		conn.setRequestProperty("Accept", "application/json");
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(
+                (conn.getInputStream())));
+
+        StringBuffer output = new StringBuffer();
+        String out;
+        System.out.println("Output from Server .... \n");
+        while ((out = br.readLine()) != null) {
+            output.append(out);
+        }
+
+		conn.disconnect();
+		requestOutput = output.toString();
+        return conn.getResponseCode();
+	}
+
 	@org.junit.Test
     public void testSetUp() throws Exception {
 		Assert.assertEquals(PORT, restServer.getPort());
@@ -79,5 +109,9 @@ public class QblRESTServerTest {
 		Assert.assertNull(restServer.getServer());
 		restServer.run();
 		Assert.assertNotNull(restServer.getServer());
+		Assert.assertEquals(200, sendRequest("status", "GET"));
+		Assert.assertEquals("{status: \"running\"}", requestOutput);
 	}
+
+
 }

--- a/src/test/java/de/qabel/desktop/QblRESTServerTest.java
+++ b/src/test/java/de/qabel/desktop/QblRESTServerTest.java
@@ -1,0 +1,83 @@
+package de.qabel.desktop;
+
+import com.sun.net.httpserver.HttpServer;
+import de.qabel.ackack.event.EventEmitter;
+import de.qabel.core.config.*;
+import de.qabel.core.crypto.QblECKeyPair;
+import de.qabel.core.drop.DropActor;
+import de.qabel.core.drop.DropURL;
+import de.qabel.core.module.ModuleManager;
+import de.qabel.desktop.QblRESTServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Assert;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Created by dax on 24.09.15.
+ */
+public class QblRESTServerTest {
+
+	private static final String DB_NAME = "QblHelloWorldModuleTest.sqlite";
+	private static final String BOB_DROP_URL = "http://localhost:6000/123456789012345678901234567890123456789012b";
+	public static final int PORT = 9696;
+	private ModuleManager moduleManager;
+	private QblRESTServer restServer;
+	private DropActor dropActor;
+	private ResourceActor resourceActor;
+
+	@Before
+	public void setUp() throws Exception {
+		Persistence<String> persistence = new SQLitePersistence(DB_NAME, "qabel".toCharArray());
+		resourceActor = new ResourceActor(persistence, EventEmitter.getDefault());
+		moduleManager = new ModuleManager(EventEmitter.getDefault(), resourceActor);
+
+		Collection<DropURL> bobDropURLs = new ArrayList<>();
+		bobDropURLs.add(new DropURL(BOB_DROP_URL));
+
+		Identity alice = new Identity("Alice", null, new QblECKeyPair());
+		Identity bob = new Identity("Bob", bobDropURLs, new QblECKeyPair());
+
+		Identities identities = new Identities();
+		identities.put(alice);
+		moduleManager.getResourceActor().writeIdentities(identities.getIdentities().toArray(new Identity[0]));
+
+		Contact bobAsContactForAlice = new Contact(alice, "Bob", bobDropURLs, bob.getEcPublicKey());
+
+		Contacts contacts = new Contacts();
+		contacts.put(bobAsContactForAlice);
+		moduleManager.getResourceActor().writeContacts(contacts.getContacts().toArray(new Contact[0]));
+
+		dropActor = new DropActor(resourceActor, EventEmitter.getDefault());
+		Thread dropActorThread = new Thread(dropActor);
+		dropActor.setInterval(500);
+		dropActorThread.start();
+
+		restServer = new QblRESTServer(PORT, resourceActor, dropActor,moduleManager);
+	}
+
+	@After
+	public void tearDown() throws InterruptedException {
+		if (restServer != null) {
+			restServer.stop();
+		}
+		File persistenceTestDB = new File(DB_NAME);
+		if(persistenceTestDB.exists()) {
+			persistenceTestDB.delete();
+		}
+	}
+
+	@org.junit.Test
+    public void testSetUp() throws Exception {
+		Assert.assertEquals(PORT, restServer.getPort());
+		Assert.assertEquals(dropActor, restServer.getDropActor());
+		Assert.assertEquals(moduleManager, restServer.getModuleManager());
+		Assert.assertEquals(resourceActor, restServer.getResourceActor());
+		Assert.assertNull(restServer.getServer());
+		restServer.run();
+		Assert.assertNotNull(restServer.getServer());
+	}
+}

--- a/src/test/java/de/qabel/desktop/QblRESTServerTest.java
+++ b/src/test/java/de/qabel/desktop/QblRESTServerTest.java
@@ -35,7 +35,7 @@ public class QblRESTServerTest {
 		Persistence<String> persistence = new SQLitePersistence(DB_NAME, "qabel".toCharArray());
 		resourceActor = new ResourceActor(persistence, EventEmitter.getDefault());
 		moduleManager = new ModuleManager(EventEmitter.getDefault(), resourceActor);
-		restServer = new QblRESTServer(PORT, resourceActor, dropActor,moduleManager);
+		restServer = new QblRESTServer(PORT, resourceActor, dropActor, moduleManager);
 
 		Collection<DropURL> bobDropURLs = new ArrayList<>();
 		bobDropURLs.add(new DropURL(BOB_DROP_URL));
@@ -63,34 +63,34 @@ public class QblRESTServerTest {
 	public void tearDown() throws InterruptedException {
 		restServer.stop();
 		File persistenceTestDB = new File(DB_NAME);
-		if(persistenceTestDB.exists()) {
+		if (persistenceTestDB.exists()) {
 			persistenceTestDB.delete();
 		}
 	}
 
 	private int sendRequest(String ressource, String method) throws IOException {
 		String address = "http://localhost:" + PORT + "/" + ressource;
-        URL url = new URL(address);
+		URL url = new URL(address);
 		HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 		conn.setRequestMethod(method);
 		conn.setRequestProperty("Accept", "application/json");
 
-        BufferedReader br = new BufferedReader(new InputStreamReader(
-                (conn.getInputStream())));
+		BufferedReader br = new BufferedReader(new InputStreamReader(
+				(conn.getInputStream())));
 
-        StringBuffer output = new StringBuffer();
-        String out;
-        while ((out = br.readLine()) != null) {
-            output.append(out);
-        }
+		StringBuffer output = new StringBuffer();
+		String out;
+		while ((out = br.readLine()) != null) {
+			output.append(out);
+		}
 
 		conn.disconnect();
 		requestOutput = output.toString();
-        return conn.getResponseCode();
+		return conn.getResponseCode();
 	}
 
 	@org.junit.Test
-    public void testSetUp() throws Exception {
+	public void testSetUp() throws Exception {
 		restServer.run();
 		Assert.assertEquals(200, sendRequest("status", "GET"));
 		Assert.assertEquals("{status: \"running\"}", requestOutput);


### PR DESCRIPTION
Implements a REST-server that is started in a thread of the qabel-desktop application which exposes all resources that are needed by user interfaces.

This allows us to decouple the user interfaces completely from the qabel-core.


See: #26 and https://github.com/Qabel/qabel.github.io/issues/99 and the documentation pull request https://github.com/Qabel/qabel.github.io/pull/100

Should be ready to merge now.