### PR TITLE
#34 integrated TransferManager to RemoteFS browser

### DIFF
--- a/src/main/java/de/qabel/desktop/DesktopClient.java
+++ b/src/main/java/de/qabel/desktop/DesktopClient.java
@@ -58,6 +58,7 @@ public class DesktopClient extends Application {
 
 		boxVolumeFactory = new CachedBoxVolumeFactory(new S3BoxVolumeFactory());
 		ClientConfiguration config = initDiContainer();
+		new Thread(getSyncDaemon(config)).start();
 
 		SceneAntialiasing aa = SceneAntialiasing.DISABLED;
 		primaryStage.getIcons().setAll(new javafx.scene.image.Image(getClass().getResourceAsStream("/logo-invert_small.png")));
@@ -78,7 +79,6 @@ public class DesktopClient extends Application {
 		primaryStage.setScene(scene);
 		setTrayIcon(primaryStage);
 
-		new Thread(getSyncDaemon(config)).start();
 
 		Runtime.getRuntime().addShutdownHook(new Thread() {
 			public void run() {
@@ -90,10 +90,11 @@ public class DesktopClient extends Application {
 
 	protected SyncDaemon getSyncDaemon(ClientConfiguration config) {
 
-		DefaultTransferManager loadManager = new DefaultTransferManager();
-		customProperties.put("loadManager", loadManager);
-		new Thread(loadManager, "TransactionManager").start();
-		return new SyncDaemon(config.getBoxSyncConfigs(), new DefaultSyncerFactory(boxVolumeFactory, loadManager));
+		DefaultTransferManager transferManager = new DefaultTransferManager();
+		customProperties.put("loadManager", transferManager);
+		customProperties.put("transferManager", transferManager);
+		new Thread(transferManager, "TransactionManager").start();
+		return new SyncDaemon(config.getBoxSyncConfigs(), new DefaultSyncerFactory(boxVolumeFactory, transferManager));
 	}
 
 	private ClientConfiguration initDiContainer() throws QblInvalidEncryptionKeyException, URISyntaxException {

--- a/src/main/java/de/qabel/desktop/DesktopClient.java
+++ b/src/main/java/de/qabel/desktop/DesktopClient.java
@@ -7,7 +7,7 @@ import de.qabel.core.config.SQLitePersistence;
 import de.qabel.core.exceptions.QblInvalidEncryptionKeyException;
 import de.qabel.desktop.config.ClientConfiguration;
 import de.qabel.desktop.config.factory.*;
-import de.qabel.desktop.daemon.management.DefaultLoadManager;
+import de.qabel.desktop.daemon.management.DefaultTransferManager;
 import de.qabel.desktop.daemon.sync.SyncDaemon;
 import de.qabel.desktop.daemon.sync.worker.DefaultSyncerFactory;
 import de.qabel.desktop.repository.AccountRepository;
@@ -90,7 +90,7 @@ public class DesktopClient extends Application {
 
 	protected SyncDaemon getSyncDaemon(ClientConfiguration config) {
 
-		DefaultLoadManager loadManager = new DefaultLoadManager();
+		DefaultTransferManager loadManager = new DefaultTransferManager();
 		customProperties.put("loadManager", loadManager);
 		new Thread(loadManager, "TransactionManager").start();
 		return new SyncDaemon(config.getBoxSyncConfigs(), new DefaultSyncerFactory(boxVolumeFactory, loadManager));

--- a/src/main/java/de/qabel/desktop/config/factory/CachedBoxVolumeFactory.java
+++ b/src/main/java/de/qabel/desktop/config/factory/CachedBoxVolumeFactory.java
@@ -1,0 +1,30 @@
+package de.qabel.desktop.config.factory;
+
+import de.qabel.core.config.Account;
+import de.qabel.core.config.Identity;
+import de.qabel.desktop.storage.BoxVolume;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CachedBoxVolumeFactory implements BoxVolumeFactory {
+	private BoxVolumeFactory factory;
+	private Map<Account, Map<Identity, BoxVolume>> volumes = new HashMap<>();
+
+	public CachedBoxVolumeFactory(BoxVolumeFactory factory) {
+		this.factory = factory;
+	}
+
+	@Override
+	public synchronized BoxVolume getVolume(Account account, Identity identity) {
+		if (!volumes.containsKey(account) || !volumes.get(account).containsKey(identity)) {
+			if (!volumes.containsKey(account)) {
+				volumes.put(account, new HashMap<>());
+			}
+
+			volumes.get(account).put(identity, factory.getVolume(account, identity));
+		}
+
+		return volumes.get(account).get(identity);
+	}
+}

--- a/src/main/java/de/qabel/desktop/config/factory/S3BoxVolumeFactory.java
+++ b/src/main/java/de/qabel/desktop/config/factory/S3BoxVolumeFactory.java
@@ -4,6 +4,7 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import de.qabel.core.config.Account;
 import de.qabel.core.config.Identity;
 import de.qabel.desktop.daemon.management.MagicEvilPrefixSource;
+import de.qabel.desktop.exceptions.QblStorageException;
 import de.qabel.desktop.storage.BoxVolume;
 import de.qabel.desktop.storage.cache.CachedBoxVolume;
 
@@ -12,13 +13,16 @@ import java.io.File;
 public class S3BoxVolumeFactory implements BoxVolumeFactory {
 	@Override
 	public BoxVolume getVolume(Account account, Identity identity) {
-		return new CachedBoxVolume(
-				"qabel",
-				MagicEvilPrefixSource.getPrefix(account),
+		String prefix = MagicEvilPrefixSource.getPrefix(account);
+		String bucket = "qabel";
+		CachedBoxVolume volume = new CachedBoxVolume(
+				bucket,
+				prefix,
 				new DefaultAWSCredentialsProviderChain().getCredentials(),
 				identity.getPrimaryKeyPair(),
 				new byte[0],
 				new File(System.getProperty("java.io.tmpdir"))
 		);
+		return volume;
 	}
 }

--- a/src/main/java/de/qabel/desktop/daemon/management/AbstractManualTransaction.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/AbstractManualTransaction.java
@@ -1,0 +1,57 @@
+package de.qabel.desktop.daemon.management;
+
+import de.qabel.desktop.storage.BoxVolume;
+
+import java.nio.file.Path;
+
+public abstract class AbstractManualTransaction extends AbstractTransaction {
+	protected final TYPE type;
+	protected final BoxVolume volume;
+	protected final Path source;
+	protected final Path destination;
+	protected final boolean isDir;
+
+	public AbstractManualTransaction(Long mtime, boolean isDir, Path destination, Path source, TYPE type, BoxVolume volume) {
+		super(mtime);
+		this.isDir = isDir;
+		this.destination = destination;
+		this.source = source;
+		this.type = type;
+		this.volume = volume;
+	}
+
+	@Override
+	public TYPE getType() {
+		return type;
+	}
+
+	@Override
+	public BoxVolume getBoxVolume() {
+		return volume;
+	}
+
+	@Override
+	public Path getSource() {
+		return source;
+	}
+
+	@Override
+	public Path getDestination() {
+		return destination;
+	}
+
+	@Override
+	public boolean isValid() {
+		return true;
+	}
+
+	@Override
+	public boolean isDir() {
+		return isDir;
+	}
+
+	@Override
+	public long getStagingDelayMillis() {
+		return 0;
+	}
+}

--- a/src/main/java/de/qabel/desktop/daemon/management/AbstractTransaction.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/AbstractTransaction.java
@@ -12,6 +12,7 @@ public abstract class AbstractTransaction extends Observable implements Transact
 	private List<Runnable> successHandler = new LinkedList<>();
 	private List<Runnable> failureHandler = new LinkedList<>();
 	private List<Runnable> skippedHandler = new LinkedList<>();
+	private List<Runnable> progressHandler = new LinkedList<>();
 	private long creationTime = System.currentTimeMillis();
 	private Long size;
 	private long progress = 0L;
@@ -28,6 +29,7 @@ public abstract class AbstractTransaction extends Observable implements Transact
 	@Override
 	public void toState(STATE state) {
 		this.state = state;
+		progressHandler.forEach(Runnable::run);
 	}
 
 	@Override
@@ -65,6 +67,12 @@ public abstract class AbstractTransaction extends Observable implements Transact
 	}
 
 	@Override
+	public Transaction onProgress(Runnable runnable) {
+		progressHandler.add(runnable);
+		return this;
+	}
+
+	@Override
 	public long transactionAge() {
 		return System.currentTimeMillis() - creationTime;
 	}
@@ -91,5 +99,6 @@ public abstract class AbstractTransaction extends Observable implements Transact
 	@Override
 	public void setProgress(long progress) {
 		this.progress = progress;
+		progressHandler.forEach(Runnable::run);
 	}
 }

--- a/src/main/java/de/qabel/desktop/daemon/management/AbstractTransaction.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/AbstractTransaction.java
@@ -2,16 +2,20 @@ package de.qabel.desktop.daemon.management;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Observable;
 
 import static de.qabel.desktop.daemon.management.Transaction.STATE.*;
 
-public abstract class AbstractTransaction implements Transaction {
+public abstract class AbstractTransaction extends Observable implements Transaction {
 	private STATE state = STATE.INITIALIZING;
 	protected Long mtime;
 	private List<Runnable> successHandler = new LinkedList<>();
 	private List<Runnable> failureHandler = new LinkedList<>();
 	private List<Runnable> skippedHandler = new LinkedList<>();
 	private long creationTime = System.currentTimeMillis();
+	private Long size;
+	private long progress = 0L;
+
 	public AbstractTransaction(Long mtime) {
 		this.mtime = mtime;
 	}
@@ -63,5 +67,29 @@ public abstract class AbstractTransaction implements Transaction {
 	@Override
 	public long transactionAge() {
 		return System.currentTimeMillis() - creationTime;
+	}
+
+	@Override
+	public long getSize() {
+		return size;
+	}
+
+	public void setSize(long size) {
+		this.size = size;
+	}
+
+	@Override
+	public boolean hasSize() {
+		return size != null;
+	}
+
+	@Override
+	public long getProgress() {
+		return progress;
+	}
+
+	@Override
+	public void setProgress(long progress) {
+		this.progress = progress;
 	}
 }

--- a/src/main/java/de/qabel/desktop/daemon/management/BoxSyncBasedDownload.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/BoxSyncBasedDownload.java
@@ -32,4 +32,9 @@ public class BoxSyncBasedDownload extends AbstractBoxSyncBasedTransaction implem
 	public void setMtime(Long mtime) {
 		this.mtime = mtime;
 	}
+
+	@Override
+	public long getStagingDelayMillis() {
+		return 0;
+	}
 }

--- a/src/main/java/de/qabel/desktop/daemon/management/BoxSyncBasedUpload.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/BoxSyncBasedUpload.java
@@ -1,17 +1,40 @@
 package de.qabel.desktop.daemon.management;
 
 import de.qabel.desktop.config.BoxSyncConfig;
+import de.qabel.desktop.daemon.sync.event.ChangeEvent;
 import de.qabel.desktop.daemon.sync.event.WatchEvent;
 import de.qabel.desktop.storage.BoxVolume;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 public class BoxSyncBasedUpload extends AbstractBoxSyncBasedTransaction implements Upload {
+	public static Logger logger = LoggerFactory.getLogger(BoxSyncBasedUpload.class.getSimpleName());
+
 	private long stagingDelayMills = TimeUnit.SECONDS.toMillis(2);
 
 	public BoxSyncBasedUpload(BoxVolume volume, BoxSyncConfig boxSyncConfig,  WatchEvent event) {
 		super(volume, event, boxSyncConfig);
+
+		if (hasSize(event)) {
+			try {
+				setSize(Files.size(event.getPath()));
+			} catch (IOException e) {
+				logger.warn("failed to get filesize: " + e.getMessage(), e);
+			}
+		}
+	}
+
+	protected static boolean hasSize(WatchEvent event) {
+		return !Files.isDirectory(event.getPath())
+				&& (
+				!(event instanceof ChangeEvent)
+						|| ((ChangeEvent) event).getType() != ChangeEvent.TYPE.DELETE
+		);
 	}
 
 	@Override

--- a/src/main/java/de/qabel/desktop/daemon/management/BoxSyncBasedUpload.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/BoxSyncBasedUpload.java
@@ -5,8 +5,11 @@ import de.qabel.desktop.daemon.sync.event.WatchEvent;
 import de.qabel.desktop.storage.BoxVolume;
 
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
 public class BoxSyncBasedUpload extends AbstractBoxSyncBasedTransaction implements Upload {
+	private long stagingDelayMills = TimeUnit.SECONDS.toMillis(2);
+
 	public BoxSyncBasedUpload(BoxVolume volume, BoxSyncConfig boxSyncConfig,  WatchEvent event) {
 		super(volume, event, boxSyncConfig);
 	}
@@ -20,6 +23,15 @@ public class BoxSyncBasedUpload extends AbstractBoxSyncBasedTransaction implemen
 	@Override
 	public boolean isValid() {
 		return event.isValid();
+	}
+
+	@Override
+	public long getStagingDelayMillis() {
+		return stagingDelayMills;
+	}
+
+	public void setStagingDelayMills(long stagingDelayMills) {
+		this.stagingDelayMills = stagingDelayMills;
 	}
 
 	@Override

--- a/src/main/java/de/qabel/desktop/daemon/management/BoxSyncBasedUploadFactory.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/BoxSyncBasedUploadFactory.java
@@ -1,0 +1,21 @@
+package de.qabel.desktop.daemon.management;
+
+import de.qabel.desktop.config.BoxSyncConfig;
+import de.qabel.desktop.daemon.sync.event.WatchEvent;
+import de.qabel.desktop.storage.cache.CachedBoxVolume;
+
+import java.util.concurrent.TimeUnit;
+
+public class BoxSyncBasedUploadFactory {
+	private long syncDelayMills = TimeUnit.SECONDS.toMillis(2);
+
+	public BoxSyncBasedUpload getUpload(CachedBoxVolume volume, BoxSyncConfig config, WatchEvent event) {
+		BoxSyncBasedUpload boxSyncBasedUpload = new BoxSyncBasedUpload(volume, config, event);
+		boxSyncBasedUpload.setStagingDelayMills(syncDelayMills);
+		return boxSyncBasedUpload;
+	}
+
+	public void setSyncDelayMills(long syncDelayMills) {
+		this.syncDelayMills = syncDelayMills;
+	}
+}

--- a/src/main/java/de/qabel/desktop/daemon/management/DefaultTransferManager.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/DefaultTransferManager.java
@@ -26,8 +26,8 @@ import static de.qabel.desktop.daemon.management.Transaction.TYPE.CREATE;
 import static de.qabel.desktop.daemon.management.Transaction.TYPE.DELETE;
 import static de.qabel.desktop.daemon.management.Transaction.TYPE.UPDATE;
 
-public class DefaultLoadManager extends Observable implements LoadManager, Runnable {
-	private final Logger logger = LoggerFactory.getLogger(DefaultLoadManager.class);
+public class DefaultTransferManager extends Observable implements TransferManager, Runnable {
+	private final Logger logger = LoggerFactory.getLogger(DefaultTransferManager.class);
 	private final LinkedBlockingQueue<Transaction> transactions = new LinkedBlockingQueue<>();
 	private final List<Transaction> history = new LinkedList<>();
 

--- a/src/main/java/de/qabel/desktop/daemon/management/Download.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/Download.java
@@ -2,4 +2,6 @@ package de.qabel.desktop.daemon.management;
 
 public interface Download extends Transaction {
 	void setMtime(Long mtime);
+
+	void setSize(long size);
 }

--- a/src/main/java/de/qabel/desktop/daemon/management/LoadManager.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/LoadManager.java
@@ -9,6 +9,4 @@ public interface LoadManager extends Runnable {
 	void addDownload(Download download);
 
 	List<Transaction> getHistory();
-
-	void setStagingDelay(long amount, TimeUnit unit);
 }

--- a/src/main/java/de/qabel/desktop/daemon/management/ManualDownload.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/ManualDownload.java
@@ -1,0 +1,20 @@
+package de.qabel.desktop.daemon.management;
+
+import de.qabel.desktop.storage.BoxVolume;
+
+import java.nio.file.Path;
+
+public class ManualDownload extends AbstractManualTransaction implements Download {
+	public ManualDownload(long mtime, TYPE type, BoxVolume volume, Path source, Path destination, boolean isDir) {
+		super(mtime, isDir, destination, source, type, volume);
+	}
+
+	public ManualDownload(TYPE type, BoxVolume volume, Path source, Path destination, boolean isDir) {
+		super(System.currentTimeMillis(), isDir, destination, source, type, volume);
+	}
+
+	@Override
+	public void setMtime(Long mtime) {
+		this.mtime = mtime;
+	}
+}

--- a/src/main/java/de/qabel/desktop/daemon/management/ManualUpload.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/ManualUpload.java
@@ -1,0 +1,18 @@
+package de.qabel.desktop.daemon.management;
+
+import de.qabel.desktop.storage.BoxVolume;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class ManualUpload extends AbstractManualTransaction implements Upload {
+
+	public ManualUpload(TYPE type, BoxVolume volume, Path source, Path destination) {
+		this(type, volume, source, destination, Files.isDirectory(source));
+	}
+
+	public ManualUpload(TYPE type, BoxVolume volume, Path source, Path destination, boolean isDir) {
+		super(System.currentTimeMillis(), isDir, destination, source, type, volume);
+
+	}
+}

--- a/src/main/java/de/qabel/desktop/daemon/management/Transaction.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/Transaction.java
@@ -27,6 +27,8 @@ public interface Transaction extends AutoCloseable {
 
 	Transaction onSkipped(Runnable runnable);
 
+	Transaction onProgress(Runnable runnable);
+
 	long getStagingDelayMillis();
 
 	/**
@@ -51,6 +53,7 @@ public interface Transaction extends AutoCloseable {
 	void setProgress(long progress);
 
 	void setSize(long size);
+
 
 	enum TYPE { CREATE, UPDATE, DELETE }
 	enum STATE { INITIALIZING, SCHEDULED, RUNNING, FINISHED, FAILED, WAITING, SKIPPED }

--- a/src/main/java/de/qabel/desktop/daemon/management/Transaction.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/Transaction.java
@@ -29,6 +29,29 @@ public interface Transaction extends AutoCloseable {
 
 	long getStagingDelayMillis();
 
+	/**
+	 * Get the size of the transaction.
+	 * Please check hasSize() before calling getSize() to ensure a size exists.
+	 *
+	 * @return size in bytes
+	 * @throws NullPointerException if no size is set
+	 */
+	long getSize();
+
+	boolean hasSize();
+
+	/**
+	 * @return progress in bytes
+	 */
+	long getProgress();
+
+	/**
+	 * @param progress in bytes
+	 */
+	void setProgress(long progress);
+
+	void setSize(long size);
+
 	enum TYPE { CREATE, UPDATE, DELETE }
 	enum STATE { INITIALIZING, SCHEDULED, RUNNING, FINISHED, FAILED, WAITING, SKIPPED }
 

--- a/src/main/java/de/qabel/desktop/daemon/management/Transaction.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/Transaction.java
@@ -27,6 +27,8 @@ public interface Transaction extends AutoCloseable {
 
 	Transaction onSkipped(Runnable runnable);
 
+	long getStagingDelayMillis();
+
 	enum TYPE { CREATE, UPDATE, DELETE }
 	enum STATE { INITIALIZING, SCHEDULED, RUNNING, FINISHED, FAILED, WAITING, SKIPPED }
 

--- a/src/main/java/de/qabel/desktop/daemon/management/TransactionRelatedProgressListener.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/TransactionRelatedProgressListener.java
@@ -1,0 +1,21 @@
+package de.qabel.desktop.daemon.management;
+
+import de.qabel.desktop.storage.ProgressListener;
+
+public class TransactionRelatedProgressListener extends ProgressListener {
+	private Transaction transaction;
+
+	public TransactionRelatedProgressListener(Transaction transaction) {
+		this.transaction = transaction;
+	}
+
+	@Override
+	public void setProgress(long progress) {
+		transaction.setProgress(progress);
+	}
+
+	@Override
+	public void setSize(long size) {
+		transaction.setSize(size);
+	}
+}

--- a/src/main/java/de/qabel/desktop/daemon/management/TransferManager.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/TransferManager.java
@@ -3,7 +3,7 @@ package de.qabel.desktop.daemon.management;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-public interface LoadManager extends Runnable {
+public interface TransferManager extends Runnable {
 	List<Transaction> getTransactions();
 	void addUpload(Upload upload);
 	void addDownload(Download download);

--- a/src/main/java/de/qabel/desktop/daemon/management/Upload.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/Upload.java
@@ -1,5 +1,4 @@
 package de.qabel.desktop.daemon.management;
 
 public interface Upload extends Transaction {
-
 }

--- a/src/main/java/de/qabel/desktop/daemon/sync/event/RemoteChangeEvent.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/event/RemoteChangeEvent.java
@@ -1,14 +1,37 @@
 package de.qabel.desktop.daemon.sync.event;
 
+import de.qabel.desktop.storage.BoxNavigation;
+import de.qabel.desktop.storage.BoxObject;
+
 import java.nio.file.Path;
 
 public class RemoteChangeEvent extends AbstractChangeEvent implements ChangeEvent {
-	public RemoteChangeEvent(Path path, boolean isDirecotry, Long mtime, ChangeEvent.TYPE type) {
+	private final BoxObject boxObject;
+	private final BoxNavigation navigation;
+
+	public RemoteChangeEvent(
+			Path path,
+			boolean isDirecotry,
+			Long mtime,
+			ChangeEvent.TYPE type,
+			BoxObject boxObject,
+			BoxNavigation navigation
+	) {
 		super(path, isDirecotry, mtime, type);
+		this.boxObject = boxObject;
+		this.navigation = navigation;
 	}
 
 	@Override
 	public boolean isValid() {
 		return true;
+	}
+
+	public BoxObject getBoxObject() {
+		return boxObject;
+	}
+
+	public BoxNavigation getBoxNavigation() {
+		return navigation;
 	}
 }

--- a/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
@@ -1,10 +1,7 @@
 package de.qabel.desktop.daemon.sync.worker;
 
 import de.qabel.desktop.config.BoxSyncConfig;
-import de.qabel.desktop.daemon.management.BoxSyncBasedDownload;
-import de.qabel.desktop.daemon.management.BoxSyncBasedUpload;
-import de.qabel.desktop.daemon.management.LoadManager;
-import de.qabel.desktop.daemon.management.Transaction;
+import de.qabel.desktop.daemon.management.*;
 import de.qabel.desktop.daemon.sync.event.ChangeEvent;
 import de.qabel.desktop.daemon.sync.event.LocalDeleteEvent;
 import de.qabel.desktop.daemon.sync.event.RemoteChangeEvent;
@@ -17,15 +14,17 @@ import de.qabel.desktop.storage.cache.CachedBoxVolume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 public class DefaultSyncer implements Syncer {
+	private BoxSyncBasedUploadFactory uploadFactory = new BoxSyncBasedUploadFactory();
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 	private CachedBoxVolume boxVolume;
 	private BoxSyncConfig config;
 	private LoadManager manager;
-	private int pollInterval = 5;
+	private int pollInterval = 2;
 	private TimeUnit pollUnit = TimeUnit.SECONDS;
 	private Thread poller;
 	private TreeWatcher watcher;
@@ -116,7 +115,7 @@ public class DefaultSyncer implements Syncer {
 	}
 
 	private void upload(WatchEvent event) {
-		BoxSyncBasedUpload upload = new BoxSyncBasedUpload(boxVolume, config, event);
+		BoxSyncBasedUpload upload = uploadFactory.getUpload(boxVolume, config, event);
 		if (isUpToDate(upload)) {
 			downloadUnnoticedDelete(upload);
 			return;
@@ -134,8 +133,9 @@ public class DefaultSyncer implements Syncer {
 	private void downloadUnnoticedDelete(BoxSyncBasedUpload upload) {
 		Path destination = upload.getDestination();
 		boolean exists;
+		BoxNavigation nav = null;
 		try {
-			BoxNavigation nav = upload.getBoxVolume().navigate();
+			nav = upload.getBoxVolume().navigate();
 			for (int i = 0; i < destination.getNameCount() - 1; i++) {
 				nav = nav.navigate(destination.getName(i).toString());
 			}
@@ -150,14 +150,19 @@ public class DefaultSyncer implements Syncer {
 					upload.getDestination(),
 					upload.isDir(),
 					System.currentTimeMillis(),
-					ChangeEvent.TYPE.DELETE
+					ChangeEvent.TYPE.DELETE,
+					null, nav
 			);
 			download(inverseEvent);
 		}
 	}
 
 	protected void startWatcher() {
-		watcher = new TreeWatcher(config.getLocalPath(), watchEvent -> {
+		Path localPath = config.getLocalPath();
+		if (!Files.isDirectory(localPath) || !Files.isReadable(localPath)) {
+			throw new IllegalStateException("local dir " + localPath.toString() + " is not valid");
+		}
+		watcher = new TreeWatcher(localPath, watchEvent -> {
 			if (!watchEvent.isValid()) {
 				return;
 			}
@@ -195,5 +200,13 @@ public class DefaultSyncer implements Syncer {
 		while (!polling && !watcher.isWatching()) {
 			Thread.yield();
 		}
+	}
+
+	public BoxSyncBasedUploadFactory getUploadFactory() {
+		return uploadFactory;
+	}
+
+	public void setUploadFactory(BoxSyncBasedUploadFactory uploadFactory) {
+		this.uploadFactory = uploadFactory;
 	}
 }

--- a/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
@@ -1,5 +1,8 @@
 package de.qabel.desktop.daemon.sync.worker;
 
+import de.qabel.desktop.daemon.management.BoxSyncBasedUpload;
+import de.qabel.desktop.daemon.management.TransferManager;
+
 import de.qabel.desktop.config.BoxSyncConfig;
 import de.qabel.desktop.daemon.management.*;
 import de.qabel.desktop.daemon.sync.event.ChangeEvent;
@@ -9,7 +12,6 @@ import de.qabel.desktop.daemon.sync.event.WatchEvent;
 import de.qabel.desktop.daemon.sync.worker.index.SyncIndex;
 import de.qabel.desktop.exceptions.QblStorageException;
 import de.qabel.desktop.storage.BoxNavigation;
-import de.qabel.desktop.storage.cache.CachedBoxNavigation;
 import de.qabel.desktop.storage.cache.CachedBoxVolume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +25,7 @@ public class DefaultSyncer implements Syncer {
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 	private CachedBoxVolume boxVolume;
 	private BoxSyncConfig config;
-	private LoadManager manager;
+	private TransferManager manager;
 	private int pollInterval = 2;
 	private TimeUnit pollUnit = TimeUnit.SECONDS;
 	private Thread poller;
@@ -31,7 +33,7 @@ public class DefaultSyncer implements Syncer {
 	private boolean polling = false;
 	private final SyncIndex index;
 
-	public DefaultSyncer(BoxSyncConfig config, CachedBoxVolume boxVolume, LoadManager manager) {
+	public DefaultSyncer(BoxSyncConfig config, CachedBoxVolume boxVolume, TransferManager manager) {
 		this.config = config;
 		this.boxVolume = boxVolume;
 		this.manager = manager;

--- a/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerFactory.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerFactory.java
@@ -2,15 +2,15 @@ package de.qabel.desktop.daemon.sync.worker;
 
 import de.qabel.desktop.config.BoxSyncConfig;
 import de.qabel.desktop.config.factory.BoxVolumeFactory;
-import de.qabel.desktop.daemon.management.LoadManager;
+import de.qabel.desktop.daemon.management.TransferManager;
 import de.qabel.desktop.storage.cache.CachedBoxVolume;
 
 public class DefaultSyncerFactory implements SyncerFactory {
-	private LoadManager manager;
+	private TransferManager manager;
 
 	private BoxVolumeFactory boxVolumeFactory;
 
-	public DefaultSyncerFactory(BoxVolumeFactory boxVolumeFactory, LoadManager manager) {
+	public DefaultSyncerFactory(BoxVolumeFactory boxVolumeFactory, TransferManager manager) {
 		this.boxVolumeFactory = boxVolumeFactory;
 		this.manager = manager;
 	}

--- a/src/main/java/de/qabel/desktop/daemon/sync/worker/TreeWatcher.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/worker/TreeWatcher.java
@@ -147,7 +147,11 @@ public class TreeWatcher extends Thread {
 				logger.trace("watching " + dir);
 				WatchKey key = dir.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
 				keys.put(key, dir);
-				consumer.accept(new WatchRegisteredEvent(dir));
+				try {
+					consumer.accept(new WatchRegisteredEvent(dir));
+				} catch (Exception e) {
+					logger.error(e.getMessage(), e);
+				}
 				return FileVisitResult.CONTINUE;
 			}
 		});

--- a/src/main/java/de/qabel/desktop/storage/BoxNavigation.java
+++ b/src/main/java/de/qabel/desktop/storage/BoxNavigation.java
@@ -6,7 +6,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 
-public interface BoxNavigation {
+public interface BoxNavigation extends ReadOnlyBoxNavigation {
 
 	DirectoryMetadata reloadMetadata() throws QblStorageException;
 
@@ -21,48 +21,6 @@ public interface BoxNavigation {
 	 * @throws QblStorageException
 	 */
 	void commit() throws QblStorageException;
-
-	/**
-	 * Create a new navigation object that starts at another {@link BoxFolder}
-	 *
-	 * @param target Target folder that is a direct subfolder
-	 * @return {@link BoxNavigation} for the subfolder
-	 * @throws QblStorageException
-	 */
-	BoxNavigation navigate(BoxFolder target) throws QblStorageException;
-
-	/**
-	 * Create a new navigation object that starts at another {@link BoxExternal}
-	 *
-	 * @param target Target shared folder that is mounted in the current folder
-	 * @return {@link BoxNavigation} for the external share
-	 * @throws QblStorageException
-	 */
-	BoxNavigation navigate(BoxExternal target);
-
-	/**
-	 * Create a list of all files in the current folder
-	 *
-	 * @return list of files
-	 * @throws QblStorageException
-	 */
-	List<BoxFile> listFiles() throws QblStorageException;
-
-	/**
-	 * Create a list of all folders in the current folder
-	 *
-	 * @return list of folders
-	 * @throws QblStorageException
-	 */
-	List<BoxFolder> listFolders() throws QblStorageException;
-
-	/**
-	 * Create a list of external shares in the current folder
-	 *
-	 * @return list of external shares
-	 * @throws QblStorageException
-	 */
-	List<BoxExternal> listExternals() throws QblStorageException;
 
 	/**
 	 * Upload a new file to the current folder
@@ -132,18 +90,6 @@ public interface BoxNavigation {
 	 */
 	void setAutocommit(boolean autocommit);
 
-	/**
-	 * Navigate to subfolder by name
-	 */
-	BoxNavigation navigate(String folderName) throws QblStorageException;
-
-	BoxFolder getFolder(String name) throws QblStorageException;
-
-	boolean hasFolder(String name) throws QblStorageException;
-
-	BoxFile getFile(String name) throws QblStorageException;
-
 	DirectoryMetadata getMetadata();
 
-	boolean hasFile(String name) throws QblStorageException;
 }

--- a/src/main/java/de/qabel/desktop/storage/BoxNavigation.java
+++ b/src/main/java/de/qabel/desktop/storage/BoxNavigation.java
@@ -27,6 +27,17 @@ public interface BoxNavigation extends ReadOnlyBoxNavigation {
 	 *
 	 * @param name name of the file, must be unique
 	 * @param file file object that must be readable
+	 * @param listener
+	 * @return the resulting BoxFile object
+	 * @throws QblStorageException if the upload failed or the name is not unique
+	 */
+	BoxFile upload(String name, File file, ProgressListener listener) throws QblStorageException;
+
+	/**
+	 * Upload a new file to the current folder
+	 *
+	 * @param name name of the file, must be unique
+	 * @param file file object that must be readable
 	 * @return the resulting BoxFile object
 	 * @throws QblStorageException if the upload failed or the name is not unique
 	 */
@@ -37,10 +48,31 @@ public interface BoxNavigation extends ReadOnlyBoxNavigation {
 	 *
 	 * @param name name of the file which must already exist
 	 * @param file file object that must be readable
+	 * @param listener
+	 * @return the updated BoxFile object
+	 * @throws QblStorageException if he upload failed or the name does not exist
+	 */
+	BoxFile overwrite(String name, File file, ProgressListener listener) throws QblStorageException;
+
+	/**
+	 * Overwrite a file in the current folder
+	 *
+	 * @param name name of the file which must already exist
+	 * @param file file object that must be readable
 	 * @return the updated BoxFile object
 	 * @throws QblStorageException if he upload failed or the name does not exist
 	 */
 	BoxFile overwrite(String name, File file) throws QblStorageException;
+
+	/**
+	 * Create an {@link InputStream} for a {@link BoxFile} in the current folder
+	 *
+	 * @param file file in the current folder
+	 * @param listener
+	 * @return Decrypted stream
+	 * @throws QblStorageException if the download or decryption failed
+	 */
+	InputStream download(BoxFile file, ProgressListener listener) throws QblStorageException;
 
 	/**
 	 * Create an {@link InputStream} for a {@link BoxFile} in the current folder

--- a/src/main/java/de/qabel/desktop/storage/BoxVolume.java
+++ b/src/main/java/de/qabel/desktop/storage/BoxVolume.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 
 public class BoxVolume {
 
-	private static final Logger logger = LoggerFactory.getLogger(BoxVolume.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(BoxVolume.class.getSimpleName());
 
 	StorageReadBackend readBackend;
 	public StorageWriteBackend writeBackend;
@@ -72,7 +72,7 @@ public class BoxVolume {
 	public BoxNavigation navigate() throws QblStorageException {
 		String rootRef = getRootRef();
 		logger.info("Navigating to " + rootRef);
-		InputStream indexDl = readBackend.download(rootRef);
+		InputStream indexDl = readBackend.download(rootRef).getInputStream();
 		File tmp;
 		try {
 			byte[] encrypted = IOUtils.toByteArray(indexDl);

--- a/src/main/java/de/qabel/desktop/storage/DirectoryMetadata.java
+++ b/src/main/java/de/qabel/desktop/storage/DirectoryMetadata.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.UUID;
 
 public class DirectoryMetadata {
-	private static final Logger logger = LoggerFactory.getLogger(DirectoryMetadata.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(DirectoryMetadata.class.getSimpleName());
 	private static final String JDBC_PREFIX = "jdbc:sqlite:";
 	public static final int TYPE_NONE = -1;
 	private final Connection connection;

--- a/src/main/java/de/qabel/desktop/storage/FolderNavigation.java
+++ b/src/main/java/de/qabel/desktop/storage/FolderNavigation.java
@@ -14,7 +14,7 @@ import java.security.InvalidKeyException;
 
 public class FolderNavigation extends AbstractNavigation {
 
-	private static final Logger logger = LoggerFactory.getLogger(FolderNavigation.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(FolderNavigation.class.getSimpleName());
 
 	private final byte[] key;
 
@@ -36,7 +36,7 @@ public class FolderNavigation extends AbstractNavigation {
 		logger.info("Reloading directory metadata");
 		// duplicate of navigate()
 		try {
-			InputStream indexDl = readBackend.download(dm.getFileName());
+			InputStream indexDl = readBackend.download(dm.getFileName()).getInputStream();
 			File tmp = File.createTempFile("dir", "db", dm.getTempDir());
 			tmp.deleteOnExit();
 			KeyParameter key = new KeyParameter(this.key);

--- a/src/main/java/de/qabel/desktop/storage/IndexNavigation.java
+++ b/src/main/java/de/qabel/desktop/storage/IndexNavigation.java
@@ -13,7 +13,7 @@ import java.security.InvalidKeyException;
 
 public class IndexNavigation extends AbstractNavigation {
 
-	private static final Logger logger = LoggerFactory.getLogger(IndexNavigation.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(IndexNavigation.class.getSimpleName());
 
 	IndexNavigation(DirectoryMetadata dm, QblECKeyPair keyPair, byte[] deviceId,
 					StorageReadBackend readBackend, StorageWriteBackend writeBackend) {
@@ -24,7 +24,7 @@ public class IndexNavigation extends AbstractNavigation {
 	public DirectoryMetadata reloadMetadata() throws QblStorageException {
 		// TODO: duplicate with BoxVoume.navigate()
 		String rootRef = dm.getFileName();
-		InputStream indexDl = readBackend.download(rootRef);
+		InputStream indexDl = readBackend.download(rootRef).getInputStream();
 		File tmp;
 		try {
 			byte[] encrypted = IOUtils.toByteArray(indexDl);

--- a/src/main/java/de/qabel/desktop/storage/LocalReadBackend.java
+++ b/src/main/java/de/qabel/desktop/storage/LocalReadBackend.java
@@ -11,21 +11,22 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class LocalReadBackend implements StorageReadBackend {
-
-	private static final Logger logger = LoggerFactory.getLogger(LocalReadBackend.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(LocalReadBackend.class.getSimpleName());
 	private final Path root;
-
 
 	public LocalReadBackend(Path root) {
 		this.root = root;
 	}
 
-
-	public InputStream download(String name) throws QblStorageException {
+	public StorageDownload download(String name) throws QblStorageException {
 		Path file = root.resolve(name);
 		logger.info("Downloading file path " + file.toString());
 		try {
-			return Files.newInputStream(file);
+			return new StorageDownload(
+					Files.newInputStream(file),
+					Files.getLastModifiedTime(file).toMillis(),
+					Files.size(file)
+			);
 		} catch (IOException e) {
 			throw new QblStorageNotFound(e);
 		}

--- a/src/main/java/de/qabel/desktop/storage/LocalReadBackend.java
+++ b/src/main/java/de/qabel/desktop/storage/LocalReadBackend.java
@@ -19,7 +19,24 @@ public class LocalReadBackend implements StorageReadBackend {
 	}
 
 	public StorageDownload download(String name) throws QblStorageException {
+		try {
+			return download(name, null);
+		} catch (UnmodifiedException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	public StorageDownload download(String name, Long ifModifiedSince) throws QblStorageException, UnmodifiedException {
 		Path file = root.resolve(name);
+
+		try {
+			if (ifModifiedSince != null && Files.getLastModifiedTime(file).toMillis() <= ifModifiedSince) {
+				throw new UnmodifiedException();
+			}
+		} catch (IOException e) {
+			// best effort
+		}
+
 		logger.info("Downloading file path " + file.toString());
 		try {
 			return new StorageDownload(

--- a/src/main/java/de/qabel/desktop/storage/LocalWriteBackend.java
+++ b/src/main/java/de/qabel/desktop/storage/LocalWriteBackend.java
@@ -14,7 +14,7 @@ import java.nio.file.Path;
 
 public class LocalWriteBackend implements StorageWriteBackend {
 
-	private static final Logger logger = LoggerFactory.getLogger(LocalReadBackend.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(LocalReadBackend.class.getSimpleName());
 	private Path root;
 
 

--- a/src/main/java/de/qabel/desktop/storage/ProgressInputStream.java
+++ b/src/main/java/de/qabel/desktop/storage/ProgressInputStream.java
@@ -1,0 +1,64 @@
+package de.qabel.desktop.storage;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Consumer;
+
+public class ProgressInputStream extends FilterInputStream {
+	private Consumer<Long> consumer;
+	private long read = 0;
+
+	/**
+	 * Creates a <code>FilterInputStream</code>
+	 * by assigning the  argument <code>in</code>
+	 * to the field <code>this.in</code> so as
+	 * to remember it for later use.
+	 *
+	 * @param in the underlying input stream, or <code>null</code> if
+	 *           this instance is to be created without an underlying stream.
+	 */
+	protected ProgressInputStream(InputStream in, Consumer<Long> consumer) {
+		super(in);
+		this.consumer = consumer;
+	}
+
+	@Override
+	public int read() throws IOException {
+		int read = super.read();
+		add(1);
+		return read;
+	}
+
+	private void add(long bytes) {
+		if (bytes <= 0) {
+			return;
+		}
+		read += bytes;
+		consumer.accept(read);
+	}
+
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException {
+		int read = super.read(b, off, len);
+		add(read);
+		return read;
+	}
+
+	@Override
+	public long skip(long n) throws IOException {
+		long skip = super.skip(n);
+		add(skip);
+		return skip;
+	}
+
+	@Override
+	public void close() throws IOException {
+		super.close();
+	}
+
+	@Override
+	public synchronized void reset() throws IOException {
+		super.reset();
+	}
+}

--- a/src/main/java/de/qabel/desktop/storage/ProgressListener.java
+++ b/src/main/java/de/qabel/desktop/storage/ProgressListener.java
@@ -1,0 +1,19 @@
+package de.qabel.desktop.storage;
+
+import java.util.function.Consumer;
+
+public abstract class ProgressListener implements Consumer<Long> {
+	@Override
+	public void accept(Long progress) {
+		setProgress(progress);
+	}
+
+	@Override
+	public Consumer<Long> andThen(Consumer<? super Long> after) {
+		return this::setProgress;
+	}
+
+	public abstract void setProgress(long progress);
+
+	public abstract void setSize(long size);
+}

--- a/src/main/java/de/qabel/desktop/storage/ReadOnlyBoxNavigation.java
+++ b/src/main/java/de/qabel/desktop/storage/ReadOnlyBoxNavigation.java
@@ -1,0 +1,62 @@
+package de.qabel.desktop.storage;
+
+import de.qabel.desktop.exceptions.QblStorageException;
+
+import java.util.List;
+
+public interface ReadOnlyBoxNavigation {
+	/**
+	 * Create a new navigation object that starts at another {@link BoxFolder}
+	 *
+	 * @param target Target folder that is a direct subfolder
+	 * @return {@link BoxNavigation} for the subfolder
+	 * @throws QblStorageException
+	 */
+	BoxNavigation navigate(BoxFolder target) throws QblStorageException;
+
+	/**
+	 * Create a new navigation object that starts at another {@link BoxExternal}
+	 *
+	 * @param target Target shared folder that is mounted in the current folder
+	 * @return {@link BoxNavigation} for the external share
+	 * @throws QblStorageException
+	 */
+	BoxNavigation navigate(BoxExternal target);
+
+	/**
+	 * Create a list of all files in the current folder
+	 *
+	 * @return list of files
+	 * @throws QblStorageException
+	 */
+	List<BoxFile> listFiles() throws QblStorageException;
+
+	/**
+	 * Create a list of all folders in the current folder
+	 *
+	 * @return list of folders
+	 * @throws QblStorageException
+	 */
+	List<BoxFolder> listFolders() throws QblStorageException;
+
+	/**
+	 * Create a list of external shares in the current folder
+	 *
+	 * @return list of external shares
+	 * @throws QblStorageException
+	 */
+	List<BoxExternal> listExternals() throws QblStorageException;
+
+	/**
+	 * Navigate to subfolder by name
+	 */
+	BoxNavigation navigate(String folderName) throws QblStorageException;
+
+	BoxFolder getFolder(String name) throws QblStorageException;
+
+	boolean hasFolder(String name) throws QblStorageException;
+
+	BoxFile getFile(String name) throws QblStorageException;
+
+	boolean hasFile(String name) throws QblStorageException;
+}

--- a/src/main/java/de/qabel/desktop/storage/S3WriteBackend.java
+++ b/src/main/java/de/qabel/desktop/storage/S3WriteBackend.java
@@ -11,7 +11,7 @@ import java.io.InputStream;
 
 public class S3WriteBackend implements StorageWriteBackend {
 
-	private static final Logger logger = LoggerFactory.getLogger(FolderNavigation.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(FolderNavigation.class.getSimpleName());
 
 	public final AmazonS3Client s3Client;
 	final String bucket;

--- a/src/main/java/de/qabel/desktop/storage/StorageDownload.java
+++ b/src/main/java/de/qabel/desktop/storage/StorageDownload.java
@@ -1,0 +1,27 @@
+package de.qabel.desktop.storage;
+
+import java.io.InputStream;
+
+public class StorageDownload {
+	private InputStream inputStream;
+	private long mtime;
+	private long size;
+
+	public StorageDownload(InputStream inputStream, long mtime, long size) {
+		this.inputStream = inputStream;
+		this.mtime = mtime;
+		this.size = size;
+	}
+
+	public InputStream getInputStream() {
+		return inputStream;
+	}
+
+	public long getMtime() {
+		return mtime;
+	}
+
+	public long getSize() {
+		return size;
+	}
+}

--- a/src/main/java/de/qabel/desktop/storage/StorageReadBackend.java
+++ b/src/main/java/de/qabel/desktop/storage/StorageReadBackend.java
@@ -10,4 +10,9 @@ public interface StorageReadBackend {
 	 * Download a file from the storage
 	 */
 	StorageDownload download(String name) throws QblStorageException;
+
+	/**
+	 * Download a file from the storage if it was modified
+	 */
+	StorageDownload download(String name, Long ifModifiedSince) throws QblStorageException, UnmodifiedException;
 }

--- a/src/main/java/de/qabel/desktop/storage/StorageReadBackend.java
+++ b/src/main/java/de/qabel/desktop/storage/StorageReadBackend.java
@@ -9,5 +9,5 @@ public interface StorageReadBackend {
 	/**
 	 * Download a file from the storage
 	 */
-	InputStream download(String name) throws QblStorageException;
+	StorageDownload download(String name) throws QblStorageException;
 }

--- a/src/main/java/de/qabel/desktop/storage/UnmodifiedException.java
+++ b/src/main/java/de/qabel/desktop/storage/UnmodifiedException.java
@@ -1,0 +1,4 @@
+package de.qabel.desktop.storage;
+
+public class UnmodifiedException extends Exception {
+}

--- a/src/main/java/de/qabel/desktop/storage/cache/CachedBoxNavigation.java
+++ b/src/main/java/de/qabel/desktop/storage/cache/CachedBoxNavigation.java
@@ -79,6 +79,11 @@ public class CachedBoxNavigation extends Observable implements BoxNavigation {
 	}
 
 	@Override
+	public BoxFile upload(String name, File file, ProgressListener listener) throws QblStorageException {
+		return nav.upload(name, file, listener);
+	}
+
+	@Override
 	public BoxFile upload(String name, File file) throws QblStorageException {
 		BoxFile upload = nav.upload(name, file);
 		notifyAsync(upload, CREATE);
@@ -90,10 +95,22 @@ public class CachedBoxNavigation extends Observable implements BoxNavigation {
 	}
 
 	@Override
+	public BoxFile overwrite(String name, File file, ProgressListener listener) throws QblStorageException {
+		BoxFile overwrite = nav.overwrite(name, file, listener);
+		notifyAsync(overwrite, UPDATE);
+		return overwrite;
+	}
+
+	@Override
 	public BoxFile overwrite(String name, File file) throws QblStorageException {
 		BoxFile overwrite = nav.overwrite(name, file);
 		notifyAsync(overwrite, UPDATE);
 		return overwrite;
+	}
+
+	@Override
+	public InputStream download(BoxFile file, ProgressListener listener) throws QblStorageException {
+		return nav.download(file, listener);
 	}
 
 	@Override

--- a/src/main/java/de/qabel/desktop/storage/cache/CachedBoxNavigation.java
+++ b/src/main/java/de/qabel/desktop/storage/cache/CachedBoxNavigation.java
@@ -80,7 +80,9 @@ public class CachedBoxNavigation extends Observable implements BoxNavigation {
 
 	@Override
 	public BoxFile upload(String name, File file, ProgressListener listener) throws QblStorageException {
-		return nav.upload(name, file, listener);
+		BoxFile upload = nav.upload(name, file, listener);
+		notifyAsync(upload, CREATE);
+		return upload;
 	}
 
 	@Override

--- a/src/main/java/de/qabel/desktop/storage/cache/CachedBoxVolume.java
+++ b/src/main/java/de/qabel/desktop/storage/cache/CachedBoxVolume.java
@@ -3,6 +3,8 @@ package de.qabel.desktop.storage.cache;
 import com.amazonaws.auth.AWSCredentials;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.desktop.exceptions.QblStorageException;
+import de.qabel.desktop.exceptions.QblStorageNotFound;
+import de.qabel.desktop.storage.BoxNavigation;
 import de.qabel.desktop.storage.BoxVolume;
 import de.qabel.desktop.storage.StorageReadBackend;
 import de.qabel.desktop.storage.StorageWriteBackend;
@@ -24,7 +26,14 @@ public class CachedBoxVolume extends BoxVolume {
 	@Override
 	public synchronized CachedBoxNavigation navigate() throws QblStorageException {
 		if (navigation == null) {
-			navigation = new CachedBoxNavigation(super.navigate(), Paths.get("/"));
+			BoxNavigation nav;
+			try {
+				nav = super.navigate();
+			} catch (QblStorageNotFound e) {
+				createIndex(getRootRef());
+				nav = super.navigate();
+			}
+			navigation = new CachedBoxNavigation(nav, Paths.get("/"));
 		}
 		return navigation;
 	}

--- a/src/main/java/de/qabel/desktop/ui/LayoutController.java
+++ b/src/main/java/de/qabel/desktop/ui/LayoutController.java
@@ -1,8 +1,11 @@
 package de.qabel.desktop.ui;
 
 import com.airhacks.afterburner.views.FXMLView;
+import com.amazonaws.services.s3.transfer.Transfer;
 import de.qabel.core.config.Identity;
 import de.qabel.desktop.config.ClientConfiguration;
+import de.qabel.desktop.daemon.management.Transaction;
+import de.qabel.desktop.daemon.management.TransferManager;
 import de.qabel.desktop.ui.accounting.AccountingView;
 import de.qabel.desktop.ui.accounting.avatar.AvatarView;
 import de.qabel.desktop.ui.actionlog.ActionlogView;
@@ -10,11 +13,10 @@ import de.qabel.desktop.ui.contact.ContactView;
 import de.qabel.desktop.ui.invite.InviteView;
 import de.qabel.desktop.ui.remotefs.RemoteFSView;
 import de.qabel.desktop.ui.sync.SyncView;
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
-import javafx.scene.control.Button;
-import javafx.scene.control.Label;
-import javafx.scene.control.ScrollPane;
+import javafx.scene.control.*;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
@@ -22,6 +24,7 @@ import javafx.scene.layout.VBox;
 
 import javax.inject.Inject;
 import java.net.URL;
+import java.util.Observable;
 import java.util.ResourceBundle;
 
 public class LayoutController extends AbstractController implements Initializable {
@@ -33,7 +36,6 @@ public class LayoutController extends AbstractController implements Initializabl
 	public Label mail;
 	@FXML
 	private VBox navi;
-
 	@FXML
 	private VBox scrollContent;
 
@@ -46,12 +48,17 @@ public class LayoutController extends AbstractController implements Initializabl
 	@FXML
 	private Pane avatarContainer;
 
-
 	@FXML
 	private ScrollPane scroll;
 
+	@FXML
+	private ProgressBar uploadProgress;
+
 	@Inject
 	private ClientConfiguration clientConfiguration;
+
+	@Inject
+	private TransferManager transferManager;
 
 	@Override
 	public void initialize(URL location, ResourceBundle resources) {
@@ -76,12 +83,37 @@ public class LayoutController extends AbstractController implements Initializabl
 
 		updateIdentity();
 		clientConfiguration.addObserver((o, arg) -> updateIdentity());
+
+		uploadProgress.setProgress(0);
+		uploadProgress.setDisable(true);
+		if (transferManager instanceof Observable) {
+			((Observable) transferManager).addObserver((o, arg) -> {
+				System.out.println("update");
+				Platform.runLater(() -> {
+					if (arg == null || !(arg instanceof Transaction)) {
+						uploadProgress.setVisible(false);
+						uploadProgress.setProgress(0);
+						return;
+					}
+
+					Transaction t = (Transaction) arg;
+					uploadProgress.setVisible(true);
+					if (t.hasSize() && t.getSize() != 0) {
+						uploadProgress.setProgress((double) t.getProgress() / (double) t.getSize());
+					} else {
+						uploadProgress.setProgress(ProgressIndicator.INDETERMINATE_PROGRESS);
+					}
+				});
+			});
+		}
 	}
 
 	private String lastAlias;
+	private Identity lastIdentity;
 
 	private void updateIdentity() {
 		Identity identity = clientConfiguration.getSelectedIdentity();
+		avatarContainer.setVisible(identity != null);
 		if (identity == null) {
 			return;
 		}

--- a/src/main/java/de/qabel/desktop/ui/remotefs/LazyBoxFolderTreeItem.java
+++ b/src/main/java/de/qabel/desktop/ui/remotefs/LazyBoxFolderTreeItem.java
@@ -1,10 +1,9 @@
 package de.qabel.desktop.ui.remotefs;
 
+import de.qabel.desktop.daemon.sync.event.ChangeEvent;
+import de.qabel.desktop.daemon.sync.event.RemoteChangeEvent;
 import de.qabel.desktop.exceptions.QblStorageException;
-import de.qabel.desktop.storage.BoxFile;
-import de.qabel.desktop.storage.BoxFolder;
-import de.qabel.desktop.storage.BoxNavigation;
-import de.qabel.desktop.storage.BoxObject;
+import de.qabel.desktop.storage.*;
 import javafx.application.Platform;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -13,61 +12,92 @@ import javafx.scene.control.TreeItem;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
-public class LazyBoxFolderTreeItem extends TreeItem<BoxObject> {
+public class LazyBoxFolderTreeItem extends TreeItem<BoxObject> implements Observer {
 	private BoxFolder folder;
-	private BoxNavigation navigation;
+	private ReadOnlyBoxNavigation navigation;
 	private boolean upToDate;
 	private boolean loading;
 	private StringProperty nameProperty;
 	private boolean isLeaf;
 	private Image fileImg = new Image(getClass().getResourceAsStream("/file.png"));
 	private static Image folderImg = new Image(LazyBoxFolderTreeItem.class.getResourceAsStream("/folder.png"));
+	private static ExecutorService executorService = Executors.newCachedThreadPool();
 
-	public LazyBoxFolderTreeItem(BoxFolder folder, BoxNavigation navigation) {
+	public LazyBoxFolderTreeItem(BoxFolder folder, ReadOnlyBoxNavigation navigation) {
 		this(folder, navigation, folderImg);
 	}
 
-	public LazyBoxFolderTreeItem(BoxFolder folder, BoxNavigation navigation, Image icon) {
+	public LazyBoxFolderTreeItem(BoxFolder folder, ReadOnlyBoxNavigation navigation, Image icon) {
 		super(folder);
 		ImageView value = new ImageView(icon);
 		super.setGraphic(value);
-
 		this.folder = folder;
 		this.navigation = navigation;
 		this.nameProperty = new SimpleStringProperty(folder.name);
+
+		if (navigation instanceof Observable) {
+			((Observable) navigation).addObserver(this);
+		}
+	}
+
+	public Path getPath() {
+		if (getParent() != null && getParent() instanceof LazyBoxFolderTreeItem) {
+			return ((LazyBoxFolderTreeItem) getParent()).getPath().resolve(folder.name);
+		}
+		return Paths.get("/");
 	}
 
 	public boolean isLoading() {
 		return loading;
 	}
 
-	BoxNavigation getNavigation() {
+	ReadOnlyBoxNavigation getNavigation() {
 		return navigation;
 	}
 
 	@Override
 	public ObservableList<TreeItem<BoxObject>> getChildren() {
 		if (!upToDate) {
-			loading = true;
-			nameProperty.set(folder.name + " (loading)");
-			upToDate = true;
-			Platform.runLater(() -> {
-				try {
-					LazyBoxFolderTreeItem.super.getChildren().setAll(calculateChildren());
-					isLeaf = super.getChildren().size() == 0;
-				} catch (QblStorageException e) {
-					nameProperty.set(folder.name + " (" + e.getMessage() + ")");
-				} finally {
-					nameProperty.set(folder.name);
-					loading = false;
-				}
-			});
+			updateAsync();
 		}
 		return super.getChildren();
+	}
+
+	protected void updateAsync() {
+		loading = true;
+		nameProperty.set(folder.name + " (loading)");
+		upToDate = true;
+
+		Runnable updater = () -> {
+			Collection<TreeItem<BoxObject>> col = null;
+			String updateError = null;
+			try {
+				col = calculateChildren();
+				LazyBoxFolderTreeItem.super.getChildren().setAll(col);
+			} catch (QblStorageException e) {
+				updateError = e.getMessage();
+			} finally {
+				isLeaf = super.getChildren().size() == 0;
+				loading = false;
+			}
+
+			final Collection<TreeItem<BoxObject>> finalCol = col;
+			final String finalUpdateError = updateError;
+			Platform.runLater(() -> {
+				if (finalCol == null) {
+					nameProperty.set(folder.name + " (" + finalUpdateError + ")");
+				} else {
+					nameProperty.set(folder.name);
+				}
+			});
+		};
+		executorService.submit(updater);
 	}
 
 	private Collection<TreeItem<BoxObject>> calculateChildren() throws QblStorageException {
@@ -93,5 +123,23 @@ public class LazyBoxFolderTreeItem extends TreeItem<BoxObject> {
 
 	public void setUpToDate(Boolean upToDate) {
 		this.upToDate = upToDate;
+	}
+
+	@Override
+	public void update(Observable o, Object arg) {
+		if (o != navigation || !(arg instanceof RemoteChangeEvent)) {
+			return;
+		}
+		RemoteChangeEvent event = (RemoteChangeEvent)arg;
+		if (event.getBoxNavigation() != navigation) {
+			return;
+		}
+
+		upToDate = false;
+		if (!isExpanded()) {
+			return;
+		}
+
+		updateAsync();
 	}
 }

--- a/src/main/java/de/qabel/desktop/ui/remotefs/LazyBoxFolderTreeItem.java
+++ b/src/main/java/de/qabel/desktop/ui/remotefs/LazyBoxFolderTreeItem.java
@@ -136,6 +136,7 @@ public class LazyBoxFolderTreeItem extends TreeItem<BoxObject> implements Observ
 		}
 
 		upToDate = false;
+		isLeaf = false;
 		if (!isExpanded()) {
 			return;
 		}

--- a/src/main/java/de/qabel/desktop/ui/remotefs/RemoteFSController.java
+++ b/src/main/java/de/qabel/desktop/ui/remotefs/RemoteFSController.java
@@ -51,7 +51,7 @@ public class RemoteFSController extends AbstractController implements Initializa
 	BoxVolumeFactory boxVolumeFactory;
 
 	@Inject
-	LoadManager loadManager;
+	TransferManager loadManager;
 
 	@FXML
 	private TreeTableView<BoxObject> treeTable;

--- a/src/main/resources/de/qabel/desktop/ui/layout.fxml
+++ b/src/main/resources/de/qabel/desktop/ui/layout.fxml
@@ -7,51 +7,66 @@
 <?import java.lang.String?>
 <BorderPane fx:id="window" fx:controller="de.qabel.desktop.ui.LayoutController" prefHeight="568.0" prefWidth="842.0" maxWidth="Infinity" maxHeight="Infinity" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
    <left>
-      <VBox styleClass="navi-container">
-         <children>
-            <HBox fx:id="selectedIdentity" styleClass="selectedIdentity">
+      <BorderPane styleClass="navi-container">
+         <center>
+            <VBox>
                <children>
-               <Pane fx:id="avatarContainer">
-                  <Label styleClass="avatar" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="50.0" minWidth="50.0" prefHeight="50.0" prefWidth="50.0">
-                     <HBox.margin>
-                        <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                     </HBox.margin>
-                  </Label>
-               </Pane>
-                  <VBox BorderPane.alignment="CENTER">
+                  <HBox fx:id="selectedIdentity" styleClass="selectedIdentity">
                      <children>
-                        <Label fx:id="alias" text="Guy Pearce">
-                           <font>
-                              <Font name="System Bold" size="15.0" />
-                           </font></Label>
-                        <Label fx:id="mail" text="guy@pearce.com" />
+                     <Pane fx:id="avatarContainer">
+                        <Label styleClass="avatar" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="50.0" minWidth="50.0" prefHeight="50.0" prefWidth="50.0">
+                           <HBox.margin>
+                              <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                           </HBox.margin>
+                        </Label>
+                     </Pane>
+                        <VBox BorderPane.alignment="CENTER">
+                           <children>
+                              <Label fx:id="alias" text="Guy Pearce">
+                                 <font>
+                                    <Font name="System Bold" size="15.0" />
+                                 </font></Label>
+                              <Label fx:id="mail" text="guy@pearce.com" />
+                           </children>
+                           <padding>
+                              <Insets top="10" left="5.0" right="5.0" />
+                           </padding>
+                        </VBox>
                      </children>
-                     <padding>
-                        <Insets top="10" left="5.0" right="5.0" />
-                     </padding>
+                  </HBox>
+                  <VBox fx:id="navi" alignment="TOP_RIGHT" styleClass="navi" BorderPane.alignment="CENTER">
+                     <children>
+                        <HBox>
+                           <children>
+                              <Button text="Button" />
+                           </children>
+                           <styleClass>
+                              <String fx:value="navi-item" />
+                              <String fx:value="active" />
+                           </styleClass>
+                        </HBox>
+                        <HBox styleClass="navi-item">
+                           <children>
+                              <Button text="Button" />
+                           </children>
+                        </HBox>
+                     </children>
                   </VBox>
                </children>
-            </HBox>
-            <VBox fx:id="navi" alignment="TOP_RIGHT" styleClass="navi" BorderPane.alignment="CENTER">
-               <children>
-                  <HBox>
-                     <children>
-                        <Button text="Button" />
-                     </children>
-                     <styleClass>
-                        <String fx:value="navi-item" />
-                        <String fx:value="active" />
-                     </styleClass>
-                  </HBox>
-                  <HBox styleClass="navi-item">
-                     <children>
-                        <Button text="Button" />
-                     </children>
-                  </HBox>
-               </children>
             </VBox>
-         </children>
-      </VBox>
+         </center>
+         <bottom>
+            <VBox fillWidth="true">
+               <children>
+                  <ProgressBar fx:id="uploadProgress" style="-fx-pref-width: 200;"/>
+               </children>
+               <padding>
+                  <Insets top="10" left="10" right="20" bottom="10"/>
+               </padding>
+            </VBox>
+         </bottom>
+      </BorderPane>
+
    </left>
    <center>
 

--- a/src/test-gui/java/de/qabel/desktop/ui/AbstractGuiTest.java
+++ b/src/test-gui/java/de/qabel/desktop/ui/AbstractGuiTest.java
@@ -63,7 +63,7 @@ public abstract class AbstractGuiTest<T> extends AbstractControllerTest {
 	}
 
 	@Override
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		if (stage != null) {
 			Platform.runLater(() -> stage.close());
 		}

--- a/src/test/java/de/qabel/desktop/cellValueFactory/BoxObjectCellValueFactoryTest.java
+++ b/src/test/java/de/qabel/desktop/cellValueFactory/BoxObjectCellValueFactoryTest.java
@@ -73,7 +73,7 @@ public class BoxObjectCellValueFactoryTest extends AbstractControllerTest {
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		try {
 			FileUtils.deleteDirectory(tempFolder.toFile());
 		} catch (IOException e) {

--- a/src/test/java/de/qabel/desktop/config/factory/CachedBoxVolumeFactoryTest.java
+++ b/src/test/java/de/qabel/desktop/config/factory/CachedBoxVolumeFactoryTest.java
@@ -1,0 +1,58 @@
+package de.qabel.desktop.config.factory;
+
+import de.qabel.core.config.Account;
+import de.qabel.core.config.Identity;
+import de.qabel.desktop.daemon.management.BoxVolumeFactoryStub;
+import de.qabel.desktop.daemon.sync.worker.BoxVolumeStub;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CachedBoxVolumeFactoryTest {
+
+	private Account account;
+	private Account account2;
+	private Identity identity;
+	private Identity identity2;
+	private BoxVolumeFactoryStub factory;
+	private BoxVolumeStub boxVolume1;
+
+	@Before
+	public void setUp() throws Exception {
+		account = new Account("a", "b", "c");
+		account2 = new Account("a2", "b2", "c2");
+		identity = new IdentityBuilderFactory(new DropUrlGenerator("http://localhost")).factory().build();
+		identity2 = new IdentityBuilderFactory(new DropUrlGenerator("http://localhost")).factory().build();
+		factory = new BoxVolumeFactoryStub();
+		boxVolume1 = new BoxVolumeStub();
+		factory.boxVolume = boxVolume1;
+	}
+
+	@Test
+	public void returnsSameFactoryForSameAccountAndIdentity() throws Exception {
+		BoxVolumeFactory sut = new CachedBoxVolumeFactory(factory);
+		assertSame(boxVolume1, sut.getVolume(account, identity));
+
+		factory.boxVolume = new BoxVolumeStub();
+		assertSame(boxVolume1, sut.getVolume(account, identity));
+	}
+
+	@Test
+	public void retunsNewFactoryForAnotherAccount() throws Exception {
+		BoxVolumeFactory sut = new CachedBoxVolumeFactory(factory);
+		sut.getVolume(account, identity);
+
+		factory.boxVolume = new BoxVolumeStub();
+		assertNotSame(boxVolume1, sut.getVolume(account2, identity));
+	}
+
+	@Test
+	public void returnsNewFactoryForAnotherIdentity() throws Exception {
+		BoxVolumeFactory sut = new CachedBoxVolumeFactory(factory);
+		sut.getVolume(account, identity);
+
+		factory.boxVolume = new BoxVolumeStub();
+		assertNotSame(boxVolume1, sut.getVolume(account, identity2));
+	}
+}

--- a/src/test/java/de/qabel/desktop/daemon/management/AbstractTransactionTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/AbstractTransactionTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 import static de.qabel.desktop.daemon.management.Transaction.STATE.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class AbstractTransactionTest {
 	private final List<Object> updates = new LinkedList<>();
@@ -36,5 +38,18 @@ public class AbstractTransactionTest {
 			t.onSkipped(() -> updates.add(SKIPPED));
 		}
 		assertEquals("missing skipped notification", 1, updates.size());
+	}
+
+	@Test
+	public void knowsWhenItHasNoSize() {
+		Transaction t = new DummyTransaction();
+		assertFalse(t.hasSize());
+	}
+
+	@Test
+	public void knowsWhenItHasASize() {
+		DummyTransaction t = new DummyTransaction();
+		t.setSize(1L);
+		assertTrue(t.hasSize());
 	}
 }

--- a/src/test/java/de/qabel/desktop/daemon/management/AbstractTransactionTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/AbstractTransactionTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 
 public class AbstractTransactionTest {
 	private final List<Object> updates = new LinkedList<>();
+	private final List<Object> progress = new LinkedList<>();
 
 	@Test
 	public void notifiesOnSuccessfulClose() {
@@ -51,5 +52,23 @@ public class AbstractTransactionTest {
 		DummyTransaction t = new DummyTransaction();
 		t.setSize(1L);
 		assertTrue(t.hasSize());
+	}
+
+	@Test
+	public void notifiesOnProgress() {
+		Transaction t = new DummyTransaction();
+		t.onProgress(() -> progress.add(null));
+		t.setProgress(10L);
+
+		assertEquals(1, progress.size());
+	}
+
+	@Test
+	public void notifiesOnStateChange() {
+		Transaction t = new DummyTransaction();
+		t.onProgress(() -> progress.add(null));
+		t.toState(FAILED);
+
+		assertEquals(1, progress.size());
 	}
 }

--- a/src/test/java/de/qabel/desktop/daemon/management/BoxSyncBasedUploadTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/BoxSyncBasedUploadTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
@@ -34,7 +35,7 @@ public class BoxSyncBasedUploadTest extends AbstractSyncTest {
 	@Test
 	public void forwardsConfig() throws Exception {
 		File file = new File(tmpDir.toFile(), "testfile");
-		file.createNewFile();
+		Files.write(file.toPath(), "12345".getBytes());
 
 		IdentityBuilderFactory identityBuilderFactory = new IdentityBuilderFactory(new DropUrlGenerator("http://localhost:5000"));
 		Identity identity = identityBuilderFactory.factory().build();
@@ -50,5 +51,6 @@ public class BoxSyncBasedUploadTest extends AbstractSyncTest {
 		assertEquals(volume, boxVolume);
 		assertEquals(new File(tmpDir.toFile(), "testfile").toPath(), upload.getSource());
 		assertEquals(Paths.get("/tmp/testfile"), upload.getDestination());
+		assertEquals(5, upload.getSize());
 	}
 }

--- a/src/test/java/de/qabel/desktop/daemon/management/DefaultLoadManagerTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/DefaultLoadManagerTest.java
@@ -62,7 +62,6 @@ public class DefaultLoadManagerTest extends AbstractSyncTest {
 			download.volume = volume;
 
 			manager = new DefaultLoadManager();
-			manager.setStagingDelay(10L, TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
 			fail(e.getMessage());
 		}
@@ -403,7 +402,7 @@ public class DefaultLoadManagerTest extends AbstractSyncTest {
 
 	@Test
 	public void skipsTempFilesWithStagingArea() throws Exception {
-		manager.setStagingDelay(500L, TimeUnit.MILLISECONDS);
+		upload.stagingDelay = 500L;
 
 		Path path = tmpPath("file");
 		File file = path.toFile();
@@ -436,7 +435,7 @@ public class DefaultLoadManagerTest extends AbstractSyncTest {
 
 	@Test
 	public void downloadsAreNotStaged() throws Exception {
-		manager.setStagingDelay(2000L, TimeUnit.MILLISECONDS);
+		download.stagingDelay = 2000L;
 
 		download.source = Paths.get("/wayne");
 		download.destination = tmpPath("wayne");

--- a/src/test/java/de/qabel/desktop/daemon/management/DefaultTransferManagerTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/DefaultTransferManagerTest.java
@@ -15,6 +15,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.omg.PortableInterceptor.SUCCESSFUL;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +26,7 @@ import java.nio.file.attribute.FileTime;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static de.qabel.desktop.daemon.management.Transaction.STATE.FAILED;
 import static de.qabel.desktop.daemon.management.Transaction.STATE.FINISHED;
 import static de.qabel.desktop.daemon.management.Transaction.STATE.SKIPPED;
 import static de.qabel.desktop.daemon.management.Transaction.TYPE.*;
@@ -129,7 +131,6 @@ public class DefaultTransferManagerTest extends AbstractSyncTest {
 		upload.source = tmpPath("file");
 		upload.destination = Paths.get("/syncRoot", "targetFile");
 		File sourceFile = upload.source.toFile();
-		sourceFile.createNewFile();
 		write("testcontent", upload.source);
 		upload.isDir = false;
 
@@ -141,6 +142,10 @@ public class DefaultTransferManagerTest extends AbstractSyncTest {
 		BoxFile boxFile = files.get(0);
 		assertEquals("targetFile", boxFile.name);
 		assertEquals("testcontent", IOUtils.toString(syncRoot.download(boxFile)));
+
+		assertTrue(upload.getSize() > sourceFile.length());
+		long encryptedSize = upload.getSize();
+		assertEquals(encryptedSize, upload.getProgress());
 	}
 
 	@Test
@@ -193,11 +198,12 @@ public class DefaultTransferManagerTest extends AbstractSyncTest {
 		upload.source = tmpPath("file");
 		upload.destination = Paths.get("/syncRoot", "targetFile");
 		write("testcontent", upload.source);
-		upload.mtime = modifyMtime(upload.source, NEWER);
+		upload.mtime = modifyMtime(upload.source, OLDER);
 		manager.upload(upload);
 
 		upload.type = Transaction.TYPE.UPDATE;
 		write("content2", upload.source);
+		upload.mtime = modifyMtime(upload.source, NEWER);
 		manager.upload(upload);
 
 		BoxNavigation syncRoot = nav().navigate("syncRoot");
@@ -446,7 +452,45 @@ public class DefaultTransferManagerTest extends AbstractSyncTest {
 		manager.addDownload(download);
 		managerNext();
 
-		waitUntil(() -> download.getState() == Transaction.STATE.FAILED, () -> download.getState().toString());
+		waitUntil(() -> download.getState() == FAILED, () -> download.getState().toString());
+	}
+
+	@Test
+	public void updatesDownloadSize() throws Exception {
+		Path file = tmpPath("file");
+		Files.write(file, "1234567890".getBytes());
+		volume.navigate().upload("file", file.toFile());
+		download.source = Paths.get("/file");
+		download.destination = tmpPath("wayne");
+		download.mtime = 10L;
+		download.type = CREATE;
+		download.isDir = false;
+		manager.addDownload(download);
+		managerNext();
+
+		waitUntil(
+				() -> download.hasSize() && download.getSize() == 10,
+				() -> download.hasSize() ? download.getSize() + " != 10" : "no size"
+		);
+	}
+
+	@Test
+	public void updatesDownloadProgress() throws Exception {
+		Path file = tmpPath("file");
+		Files.write(file, "1234567890".getBytes());
+		BoxFile remote = volume.navigate().upload("file", file.toFile());
+		download.source = Paths.get("/file");
+		download.destination = tmpPath("wayne");
+		download.mtime = remote.mtime;
+		download.type = CREATE;
+		download.isDir = false;
+		manager.addDownload(download);
+		managerNext();
+
+		waitUntil(() -> download.hasSize());
+		waitUntil(() -> download.getProgress() == download.getSize(), () -> {
+			return download.getProgress() + " != " + download.getSize();
+		});
 	}
 
 	private void assertRemoteExists(String content, String testfile) throws QblStorageException, IOException {

--- a/src/test/java/de/qabel/desktop/daemon/management/DefaultTransferManagerTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/DefaultTransferManagerTest.java
@@ -30,12 +30,12 @@ import static de.qabel.desktop.daemon.management.Transaction.STATE.SKIPPED;
 import static de.qabel.desktop.daemon.management.Transaction.TYPE.*;
 import static org.junit.Assert.*;
 
-public class DefaultLoadManagerTest extends AbstractSyncTest {
+public class DefaultTransferManagerTest extends AbstractSyncTest {
 	public static final long NEWER = 10000L;
 	public static final long OLDER = -10000L;
 	private BoxVolume volume;
 	private UploadStub upload;
-	private DefaultLoadManager manager;
+	private DefaultTransferManager manager;
 	private DownloadStub download;
 
 	private Path tmpPath(String dir) {
@@ -57,11 +57,12 @@ public class DefaultLoadManagerTest extends AbstractSyncTest {
 
 			upload = new UploadStub();
 			upload.volume = volume;
+			upload.stagingDelay = 10L;
 
 			download = new DownloadStub();
 			download.volume = volume;
 
-			manager = new DefaultLoadManager();
+			manager = new DefaultTransferManager();
 		} catch (Exception e) {
 			fail(e.getMessage());
 		}

--- a/src/test/java/de/qabel/desktop/daemon/management/DownloadStub.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/DownloadStub.java
@@ -5,4 +5,9 @@ public class DownloadStub extends TransactionStub implements Download {
 	public void setMtime(Long mtime) {
 		
 	}
+
+	@Override
+	public void setSize(long size) {
+		this.size = size;
+	}
 }

--- a/src/test/java/de/qabel/desktop/daemon/management/DummyTransaction.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/DummyTransaction.java
@@ -38,4 +38,9 @@ public class DummyTransaction extends AbstractTransaction {
 	public boolean isDir() {
 		return false;
 	}
+
+	@Override
+	public long getStagingDelayMillis() {
+		return 0;
+	}
 }

--- a/src/test/java/de/qabel/desktop/daemon/management/DummyUpload.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/DummyUpload.java
@@ -61,6 +61,11 @@ public class DummyUpload implements Upload {
 	}
 
 	@Override
+	public Transaction onProgress(Runnable runnable) {
+		return null;
+	}
+
+	@Override
 	public long getStagingDelayMillis() {
 		return 0;
 	}

--- a/src/test/java/de/qabel/desktop/daemon/management/DummyUpload.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/DummyUpload.java
@@ -61,6 +61,11 @@ public class DummyUpload implements Upload {
 	}
 
 	@Override
+	public long getStagingDelayMillis() {
+		return 0;
+	}
+
+	@Override
 	public STATE getState() {
 		return null;
 	}

--- a/src/test/java/de/qabel/desktop/daemon/management/DummyUpload.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/DummyUpload.java
@@ -66,6 +66,31 @@ public class DummyUpload implements Upload {
 	}
 
 	@Override
+	public long getSize() {
+		return 0;
+	}
+
+	@Override
+	public boolean hasSize() {
+		return false;
+	}
+
+	@Override
+	public long getProgress() {
+		return 0;
+	}
+
+	@Override
+	public void setProgress(long progress) {
+
+	}
+
+	@Override
+	public void setSize(long size) {
+
+	}
+
+	@Override
 	public STATE getState() {
 		return null;
 	}

--- a/src/test/java/de/qabel/desktop/daemon/management/ProgressInputStreamTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/ProgressInputStreamTest.java
@@ -1,0 +1,7 @@
+package de.qabel.desktop.daemon.management;
+
+import static org.junit.Assert.*;
+
+public class ProgressInputStreamTest {
+
+}

--- a/src/test/java/de/qabel/desktop/daemon/management/TransactionStub.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/TransactionStub.java
@@ -15,6 +15,7 @@ public class TransactionStub implements Transaction {
 	public Long mtime = 0L;
 	public boolean closed = false;
 	public long transactionAge = 2000L;
+	public long stagingDelay = 0L;
 
 	@Override
 	public long transactionAge() {
@@ -69,6 +70,11 @@ public class TransactionStub implements Transaction {
 	@Override
 	public Transaction onSkipped(Runnable runnable) {
 		return this;
+	}
+
+	@Override
+	public long getStagingDelayMillis() {
+		return stagingDelay;
 	}
 
 	@Override

--- a/src/test/java/de/qabel/desktop/daemon/management/TransactionStub.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/TransactionStub.java
@@ -75,6 +75,11 @@ public class TransactionStub implements Transaction {
 	}
 
 	@Override
+	public Transaction onProgress(Runnable runnable) {
+		return null;
+	}
+
+	@Override
 	public long getStagingDelayMillis() {
 		return stagingDelay;
 	}

--- a/src/test/java/de/qabel/desktop/daemon/management/TransactionStub.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/TransactionStub.java
@@ -15,6 +15,8 @@ public class TransactionStub implements Transaction {
 	public Long mtime = 0L;
 	public boolean closed = false;
 	public long transactionAge = 2000L;
+	public Long size;
+	public long progress = 0L;
 	public long stagingDelay = 0L;
 
 	@Override
@@ -90,5 +92,30 @@ public class TransactionStub implements Transaction {
 	@Override
 	public void close() {
 		closed = true;
+	}
+
+	@Override
+	public long getSize() {
+		return size;
+	}
+
+	@Override
+	public boolean hasSize() {
+		return size != null;
+	}
+
+	@Override
+	public long getProgress() {
+		return progress;
+	}
+
+	@Override
+	public void setProgress(long progress) {
+		this.progress = progress;
+	}
+
+	@Override
+	public void setSize(long size) {
+		this.size = size;
 	}
 }

--- a/src/test/java/de/qabel/desktop/daemon/sync/AbstractSyncTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/AbstractSyncTest.java
@@ -33,28 +33,18 @@ public abstract class AbstractSyncTest {
 	}
 
 	protected static void waitUntil(Callable<Boolean> evaluate) {
-		waitUntil(evaluate, null);
+		SyncUtils.waitUntil(evaluate);
 	}
 
 	protected static void waitUntil(Callable<Boolean> evaluate, Callable<String> errorMessage) {
-		waitUntil(evaluate, 1000L, errorMessage);
+		SyncUtils.waitUntil(evaluate, errorMessage);
 	}
 
 	protected static void waitUntil(Callable<Boolean> evaluate, long timeout) {
-		waitUntil(evaluate, timeout, null);
+		SyncUtils.waitUntil(evaluate, timeout);
 	}
 
 	protected static void waitUntil(Callable<Boolean> evaluate, long timeout, Callable<String> errorMessage) {
-		try {
-			long startTime = System.currentTimeMillis();
-			while (!evaluate.call()) {
-				Thread.yield();
-				if (System.currentTimeMillis() - timeout > startTime) {
-					fail(errorMessage != null ? errorMessage.call() : "wait timeout");
-				}
-			}
-		} catch (Exception e) {
-			fail(e.getMessage());
-		}
+		SyncUtils.waitUntil(evaluate, timeout, errorMessage);
 	}
 }

--- a/src/test/java/de/qabel/desktop/daemon/sync/SyncIntegrationTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/SyncIntegrationTest.java
@@ -150,13 +150,13 @@ public class SyncIntegrationTest {
 		waitUntil(() -> {
 			final SyncIntegrationTest test2 = test;
 			return Files.isDirectory(dir2);
-		}, 2000L);
+		}, 5000L);
 
 		Path file1 = Paths.get(dir1.toString(), "file");
 		Files.write(file1, "text".getBytes());
 
 		Path file2 = Paths.get(dir2.toString(), "file");
-		waitUntil(() -> Files.exists(file2), 2000L);
+		waitUntil(() -> Files.exists(file2), 5000L);
 		assertEquals("text", new String(Files.readAllBytes(file2)));
 
 		List<Transaction> history = manager2.getHistory();
@@ -176,7 +176,7 @@ public class SyncIntegrationTest {
 		assertTrue(history.get(2) instanceof Download);
 		assertEquals(Paths.get("/sync/dir"), history.get(2).getSource());
 
-		waitUntil(() -> history.size() > 3, () -> "too few events: " + history);
+		waitUntil(() -> history.size() > 3, 5000L, () -> "too few events: " + history);
 		assertTrue(
 				"an unecpected " + history.get(3) + " occured after DOWNLAOD /sync/dir",
 				history.get(3) instanceof Download

--- a/src/test/java/de/qabel/desktop/daemon/sync/SyncIntegrationTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/SyncIntegrationTest.java
@@ -65,11 +65,11 @@ public class SyncIntegrationTest {
 			volume1.navigate().createFolder("sync");
 			manager1 = new DefaultLoadManager();
 			manager2 = new DefaultLoadManager();
-			manager1.setStagingDelay(10L, TimeUnit.MILLISECONDS);
-			manager2.setStagingDelay(10L, TimeUnit.MILLISECONDS);
 
 			syncer1 = new DefaultSyncer(config1, volume1, manager1);
+			syncer1.getUploadFactory().setSyncDelayMills(0L);
 			syncer2 = new DefaultSyncer(config2, volume2, manager2);
+			syncer2.getUploadFactory().setSyncDelayMills(0L);
 
 			syncer1.setPollInterval(1, TimeUnit.MILLISECONDS);
 			syncer1.run();

--- a/src/test/java/de/qabel/desktop/daemon/sync/SyncIntegrationTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/SyncIntegrationTest.java
@@ -71,13 +71,13 @@ public class SyncIntegrationTest {
 			syncer2 = new DefaultSyncer(config2, volume2, manager2);
 			syncer2.getUploadFactory().setSyncDelayMills(0L);
 
-			syncer1.setPollInterval(1, TimeUnit.MILLISECONDS);
+			syncer1.setPollInterval(0, TimeUnit.MILLISECONDS);
 			syncer1.run();
 			syncer1.waitFor();
 			managerThread1 = new Thread(manager1);
 			managerThread1.start();
 
-			syncer2.setPollInterval(1, TimeUnit.MILLISECONDS);
+			syncer2.setPollInterval(0, TimeUnit.MILLISECONDS);
 			managerThread2 = new Thread(manager2);
 			managerThread2.start();
 		} catch (Exception e) {
@@ -150,13 +150,13 @@ public class SyncIntegrationTest {
 		waitUntil(() -> {
 			final SyncIntegrationTest test2 = test;
 			return Files.isDirectory(dir2);
-		});
+		}, 2000L);
 
 		Path file1 = Paths.get(dir1.toString(), "file");
 		Files.write(file1, "text".getBytes());
 
 		Path file2 = Paths.get(dir2.toString(), "file");
-		waitUntil(() -> Files.exists(file2));
+		waitUntil(() -> Files.exists(file2), 2000L);
 		assertEquals("text", new String(Files.readAllBytes(file2)));
 
 		List<Transaction> history = manager2.getHistory();
@@ -198,7 +198,7 @@ public class SyncIntegrationTest {
 		syncer2.run();
 		syncer2.waitFor();
 
-		waitUntil(() -> !file.exists());
+		waitUntil(() -> !file.exists(), 2000L);
 	}
 
 	@Test

--- a/src/test/java/de/qabel/desktop/daemon/sync/SyncIntegrationTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/SyncIntegrationTest.java
@@ -37,8 +37,8 @@ public class SyncIntegrationTest {
 	private Thread managerThread2;
 	private CachedBoxVolume volume1;
 	private CachedBoxVolume volume2;
-	private LoadManager manager1;
-	private LoadManager manager2;
+	private TransferManager manager1;
+	private TransferManager manager2;
 	private BoxSyncConfig config1;
 	private BoxSyncConfig config2;
 
@@ -63,8 +63,8 @@ public class SyncIntegrationTest {
 			volume2 = new CachedBoxVolume(readBackend, writeBackend, identity.getPrimaryKeyPair(), new byte[0], new File(System.getProperty("java.io.tmpdir")), "prefix");
 			volume1.createIndex("qabel", "prefix");
 			volume1.navigate().createFolder("sync");
-			manager1 = new DefaultLoadManager();
-			manager2 = new DefaultLoadManager();
+			manager1 = new DefaultTransferManager();
+			manager2 = new DefaultTransferManager();
 
 			syncer1 = new DefaultSyncer(config1, volume1, manager1);
 			syncer1.getUploadFactory().setSyncDelayMills(0L);

--- a/src/test/java/de/qabel/desktop/daemon/sync/SyncUtils.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/SyncUtils.java
@@ -1,0 +1,33 @@
+package de.qabel.desktop.daemon.sync;
+
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.fail;
+
+public class SyncUtils {
+	public static void waitUntil(Callable<Boolean> evaluate) {
+		waitUntil(evaluate, null);
+	}
+
+	public static void waitUntil(Callable<Boolean> evaluate, Callable<String> errorMessage) {
+		waitUntil(evaluate, 1000L, errorMessage);
+	}
+
+	public static void waitUntil(Callable<Boolean> evaluate, long timeout) {
+		waitUntil(evaluate, timeout, null);
+	}
+
+	public static void waitUntil(Callable<Boolean> evaluate, long timeout, Callable<String> errorMessage) {
+		try {
+			long startTime = System.currentTimeMillis();
+			while (!evaluate.call()) {
+				Thread.yield();
+				if (System.currentTimeMillis() - timeout > startTime) {
+					fail(errorMessage != null ? errorMessage.call() : "wait timeout");
+				}
+			}
+		} catch (Exception e) {
+			fail(e.getMessage());
+		}
+	}
+}

--- a/src/test/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerTest.java
@@ -6,9 +6,9 @@ import de.qabel.desktop.config.BoxSyncConfig;
 import de.qabel.desktop.config.DefaultBoxSyncConfig;
 import de.qabel.desktop.config.factory.DropUrlGenerator;
 import de.qabel.desktop.config.factory.IdentityBuilderFactory;
-import de.qabel.desktop.daemon.management.DefaultLoadManager;
+import de.qabel.desktop.daemon.management.DefaultTransferManager;
 import de.qabel.desktop.daemon.management.Download;
-import de.qabel.desktop.daemon.management.LoadManager;
+import de.qabel.desktop.daemon.management.TransferManager;
 import de.qabel.desktop.daemon.management.Transaction;
 import de.qabel.desktop.daemon.sync.AbstractSyncTest;
 import de.qabel.desktop.daemon.sync.event.ChangeEvent;
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 
 public class DefaultSyncerTest extends AbstractSyncTest {
-	private LoadManager manager;
+	private TransferManager manager;
 	private BoxSyncConfig config;
 	private Identity identity;
 	private Account account;
@@ -42,7 +42,7 @@ public class DefaultSyncerTest extends AbstractSyncTest {
 			throw new IllegalStateException(e.getMessage(), e);
 		}
 		account = new Account("a", "b", "c");
-		manager = new DefaultLoadManager();
+		manager = new DefaultTransferManager();
 		config = new DefaultBoxSyncConfig(tmpDir, Paths.get("/tmp"), identity, account);
 	}
 

--- a/src/test/java/de/qabel/desktop/storage/BoxVolumeTest.java
+++ b/src/test/java/de/qabel/desktop/storage/BoxVolumeTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 public abstract class BoxVolumeTest {
-	private static final Logger logger = LoggerFactory.getLogger(BoxVolumeTest.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(BoxVolumeTest.class.getSimpleName());
 
 	protected BoxVolume volume;
 	protected BoxVolume volume2;

--- a/src/test/java/de/qabel/desktop/storage/LocalBackendTest.java
+++ b/src/test/java/de/qabel/desktop/storage/LocalBackendTest.java
@@ -42,7 +42,7 @@ public class LocalBackendTest {
 
 	@Test
 	public void testReadTempFile() throws QblStorageException, IOException {
-		assertArrayEquals(bytes, IOUtils.toByteArray(readBackend.download(testFile)));
+		assertArrayEquals(bytes, IOUtils.toByteArray(readBackend.download(testFile).getInputStream()));
 	}
 
 	@Test
@@ -50,7 +50,7 @@ public class LocalBackendTest {
 		byte[] newBytes = bytes.clone();
 		newBytes[0] = 0;
 		writeBackend.upload(testFile, new ByteArrayInputStream(newBytes));
-		assertArrayEquals(newBytes, IOUtils.toByteArray(readBackend.download(testFile)));
+		assertArrayEquals(newBytes, IOUtils.toByteArray(readBackend.download(testFile).getInputStream()));
 		writeBackend.delete(testFile);
 		try {
 			readBackend.download(testFile);

--- a/src/test/java/de/qabel/desktop/storage/S3BackendTest.java
+++ b/src/test/java/de/qabel/desktop/storage/S3BackendTest.java
@@ -26,9 +26,9 @@ public class S3BackendTest {
 		String name = UUID.randomUUID().toString();
 
 		writeBackend.upload(name, new ByteArrayInputStream(bytes));
-		InputStream bucketDownload = bucketReadBackend.download(name);
+		InputStream bucketDownload = bucketReadBackend.download(name).getInputStream();
 		assertArrayEquals(bytes, IOUtils.toByteArray(bucketDownload));
-		InputStream download = readBackend.download(name);
+		InputStream download = readBackend.download(name).getInputStream();
 		assertArrayEquals(bytes, IOUtils.toByteArray(download));
 		writeBackend.delete(name);
 		try {

--- a/src/test/java/de/qabel/desktop/storage/cache/CachedBoxVolumeTest.java
+++ b/src/test/java/de/qabel/desktop/storage/cache/CachedBoxVolumeTest.java
@@ -1,5 +1,6 @@
 package de.qabel.desktop.storage.cache;
 
+import de.qabel.desktop.daemon.sync.SyncUtils;
 import de.qabel.desktop.daemon.sync.event.ChangeEvent;
 import de.qabel.desktop.exceptions.QblStorageException;
 import de.qabel.desktop.storage.*;
@@ -170,6 +171,7 @@ public class CachedBoxVolumeTest extends BoxVolumeTest {
 		File file = tmpfile.toFile();
 		file.deleteOnExit();
 		nav.upload("testfile", file);
+		clear(1);
 
 		Files.write(tmpfile, "content2".getBytes());
 		volume2.navigate().overwrite("testfile", file);
@@ -185,6 +187,7 @@ public class CachedBoxVolumeTest extends BoxVolumeTest {
 	public void notifiesOnDeleteFolder() throws Exception {
 		observe();
 		nav.createFolder("testfolder");
+		clear(1);
 
 		BoxNavigation nav2 = volume2.navigate();
 		nav2.delete(nav2.getFolder("testfolder"));
@@ -203,6 +206,7 @@ public class CachedBoxVolumeTest extends BoxVolumeTest {
 		file.createNewFile();
 		file.deleteOnExit();
 		BoxFile boxFile = nav.upload("testfile", file);
+		clear(1);
 
 		volume2.navigate().delete(boxFile);
 		nav.refresh();
@@ -213,11 +217,17 @@ public class CachedBoxVolumeTest extends BoxVolumeTest {
 		assertEquals("/testfile", event.getPath().toString());
 	}
 
+	protected void clear(int events) {
+		SyncUtils.waitUntil(() -> updates.size() == events);
+		updates.clear();
+	}
+
 	@Test
 	public void notifiesOnSubnavigationChanges() throws Exception {
 		observe();
-
 		nav.navigate(nav.createFolder("folder"));
+		clear(1);
+
 		volume2.navigate().navigate("folder").createFolder("subchange");
 		nav.refresh();
 

--- a/src/test/java/de/qabel/desktop/ui/AbstractControllerTest.java
+++ b/src/test/java/de/qabel/desktop/ui/AbstractControllerTest.java
@@ -7,7 +7,7 @@ import de.qabel.desktop.config.DefaultClientConfiguration;
 import de.qabel.desktop.config.factory.DropUrlGenerator;
 import de.qabel.desktop.config.factory.IdentityBuilderFactory;
 import de.qabel.desktop.daemon.management.BoxVolumeFactoryStub;
-import de.qabel.desktop.daemon.management.DefaultLoadManager;
+import de.qabel.desktop.daemon.management.DefaultTransferManager;
 import de.qabel.desktop.repository.ContactRepository;
 import de.qabel.desktop.repository.IdentityRepository;
 import de.qabel.desktop.repository.Stub.StubContactRepository;
@@ -35,7 +35,7 @@ public class AbstractControllerTest {
 	protected DefaultClientConfiguration clientConfiguration;
 	protected IdentityBuilderFactory identityBuilderFactory;
 	protected ContactRepository contactRepository = new StubContactRepository();
-	protected DefaultLoadManager loadManager;
+	protected DefaultTransferManager loadManager;
 	protected BoxVolumeFactoryStub boxVolumeFactory;
 
 
@@ -77,7 +77,7 @@ public class AbstractControllerTest {
 		diContainer.put("contactRepository", contactRepository);
 		boxVolumeFactory = new BoxVolumeFactoryStub();
 		diContainer.put("boxVolumeFactory", boxVolumeFactory);
-		loadManager = new DefaultLoadManager();
+		loadManager = new DefaultTransferManager();
 		diContainer.put("loadManager", loadManager);
 		Injector.setConfigurationSource(diContainer::get);
 		Injector.setInstanceSupplier(new RecursiveInjectionInstanceSupplier(diContainer));

--- a/src/test/java/de/qabel/desktop/ui/AbstractControllerTest.java
+++ b/src/test/java/de/qabel/desktop/ui/AbstractControllerTest.java
@@ -7,6 +7,7 @@ import de.qabel.desktop.config.DefaultClientConfiguration;
 import de.qabel.desktop.config.factory.DropUrlGenerator;
 import de.qabel.desktop.config.factory.IdentityBuilderFactory;
 import de.qabel.desktop.daemon.management.BoxVolumeFactoryStub;
+import de.qabel.desktop.daemon.management.DefaultLoadManager;
 import de.qabel.desktop.repository.ContactRepository;
 import de.qabel.desktop.repository.IdentityRepository;
 import de.qabel.desktop.repository.Stub.StubContactRepository;
@@ -22,6 +23,7 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
@@ -33,6 +35,8 @@ public class AbstractControllerTest {
 	protected DefaultClientConfiguration clientConfiguration;
 	protected IdentityBuilderFactory identityBuilderFactory;
 	protected ContactRepository contactRepository = new StubContactRepository();
+	protected DefaultLoadManager loadManager;
+	protected BoxVolumeFactoryStub boxVolumeFactory;
 
 
 	@BeforeClass
@@ -71,7 +75,10 @@ public class AbstractControllerTest {
 		diContainer.put("account", new Account("a", "b", "c"));
 		diContainer.put("identityRepository", identityRepository);
 		diContainer.put("contactRepository", contactRepository);
-		diContainer.put("boxVolumeFactory", new BoxVolumeFactoryStub());
+		boxVolumeFactory = new BoxVolumeFactoryStub();
+		diContainer.put("boxVolumeFactory", boxVolumeFactory);
+		loadManager = new DefaultLoadManager();
+		diContainer.put("loadManager", loadManager);
 		Injector.setConfigurationSource(diContainer::get);
 		Injector.setInstanceSupplier(new RecursiveInjectionInstanceSupplier(diContainer));
 	}
@@ -95,7 +102,7 @@ public class AbstractControllerTest {
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		try {
 			Injector.forgetAll();
 		} catch (Exception e) {

--- a/src/test/java/de/qabel/desktop/ui/remotefs/LazyBoxFolderTreeItemTest.java
+++ b/src/test/java/de/qabel/desktop/ui/remotefs/LazyBoxFolderTreeItemTest.java
@@ -1,5 +1,7 @@
 package de.qabel.desktop.ui.remotefs;
 
+import de.qabel.desktop.daemon.sync.event.ChangeEvent;
+import de.qabel.desktop.daemon.sync.event.RemoteChangeEvent;
 import de.qabel.desktop.exceptions.QblStorageException;
 import de.qabel.desktop.storage.*;
 import de.qabel.desktop.ui.AbstractControllerTest;
@@ -10,8 +12,10 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Observable;
 
 import static org.junit.Assert.*;
 
@@ -35,6 +39,7 @@ public class LazyBoxFolderTreeItemTest extends AbstractControllerTest {
 		((FakeBoxNavigation) item.getNavigation()).loading = false;
 		load();
 
+		waitUntil(() -> nameProperty.get().equals("name"));
 		assertEquals("name", nameProperty.get());
 	}
 
@@ -85,7 +90,6 @@ public class LazyBoxFolderTreeItemTest extends AbstractControllerTest {
 	@Test(timeout = 1000)
 	public void loadsFiles() throws Exception {
 		navigation = new FakeBoxNavigation();
-		navigation = new FakeBoxNavigation();
 		item = new LazyBoxFolderTreeItem(createSomeFolder(), navigation);
 		navigation.files.add(createSomeFile());
 
@@ -94,11 +98,32 @@ public class LazyBoxFolderTreeItemTest extends AbstractControllerTest {
 		assertEquals(1, children.size());
 	}
 
+	@Test
+	public void updatesOnNavChange() throws Exception {
+		navigation = new FakeBoxNavigation();
+		item = new LazyBoxFolderTreeItem(createSomeFolder(), navigation);
+		item.setExpanded(true);
+		List children = load();
+		assertEquals(0, children.size());
+
+		navigation.files.add(createSomeFile());
+		navigation.setChanged();
+		navigation.notifyObservers(new RemoteChangeEvent(
+				Paths.get("/name2"),
+				false,
+				navigation.files.get(0).mtime,
+				ChangeEvent.TYPE.CREATE,
+				navigation.files.get(0),
+				navigation
+		));
+		waitUntil(() -> children.size() == 1);
+	}
+
 	private BoxFile createSomeFile() {
 		return new BoxFile("ref2", "name2", 0L, 0L, new byte[0]);
 	}
 
-	private class FakeBoxNavigation implements BoxNavigation {
+	private class FakeBoxNavigation extends Observable implements BoxNavigation {
 		public boolean loading = false;
 
 		public List<BoxFile> files = new LinkedList<>();
@@ -216,6 +241,16 @@ public class LazyBoxFolderTreeItemTest extends AbstractControllerTest {
 		@Override
 		public boolean hasFile(String name) throws QblStorageException {
 			return false;
+		}
+
+		@Override
+		public synchronized void setChanged() {
+			super.setChanged();
+		}
+
+		@Override
+		public void notifyObservers() {
+			super.notifyObservers();
 		}
 	}
 }

--- a/src/test/java/de/qabel/desktop/ui/remotefs/LazyBoxFolderTreeItemTest.java
+++ b/src/test/java/de/qabel/desktop/ui/remotefs/LazyBoxFolderTreeItemTest.java
@@ -174,12 +174,27 @@ public class LazyBoxFolderTreeItemTest extends AbstractControllerTest {
 		}
 
 		@Override
+		public BoxFile upload(String name, File file, ProgressListener listener) throws QblStorageException {
+			return null;
+		}
+
+		@Override
 		public BoxFile upload(String name, File file) throws QblStorageException {
 			return null;
 		}
 
 		@Override
+		public BoxFile overwrite(String name, File file, ProgressListener listener) throws QblStorageException {
+			return null;
+		}
+
+		@Override
 		public BoxFile overwrite(String name, File file) throws QblStorageException {
+			return null;
+		}
+
+		@Override
+		public InputStream download(BoxFile file, ProgressListener listener) throws QblStorageException {
 			return null;
 		}
 

--- a/src/test/java/de/qabel/desktop/ui/remotefs/RemoteFSControllerTest.java
+++ b/src/test/java/de/qabel/desktop/ui/remotefs/RemoteFSControllerTest.java
@@ -6,6 +6,7 @@ import de.qabel.core.crypto.CryptoUtils;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.desktop.exceptions.QblStorageException;
 import de.qabel.desktop.storage.*;
+import de.qabel.desktop.storage.cache.CachedBoxVolume;
 import de.qabel.desktop.ui.AbstractControllerTest;
 import javafx.collections.ObservableList;
 import javafx.scene.control.ButtonType;
@@ -20,11 +21,15 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 
 public class RemoteFSControllerTest extends AbstractControllerTest {
@@ -37,12 +42,13 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 
 	private BoxNavigation nav;
 	private LocalWriteBackend localWrite;
-	private RemoteFSController controller = new RemoteFSController();
+	private RemoteFSController controller;
 	private UUID uuid = UUID.randomUUID();
 	private final String prefix = UUID.randomUUID().toString();
 	private File file;
 	private File localStorageFile;
 	private Path tempFolder;
+	private RemoteFSView view;
 
 	@Before
 	public void setUp() throws Exception {
@@ -61,21 +67,31 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 		localWrite = new LocalWriteBackend(tempFolder);
 		localStorageFile = new File(System.getProperty("java.io.tmpdir"));
 
-		BoxVolume volume = new BoxVolume(
+		BoxVolume volume = new CachedBoxVolume(
 				localRead,
 				localWrite,
 				keyPair,
 				deviceID,
 				localStorageFile,
 				prefix);
+		boxVolumeFactory.boxVolume = volume;
 
 		String bucket = "qabel";
 		volume.createIndex(bucket, prefix);
 		nav = volume.navigate();
+
+		Identity i = new Identity("test", null, new QblECKeyPair());
+		clientConfiguration.selectIdentity(i);
+		clientConfiguration.setAccount(new Account("http://localhost:9696","user","auth"));
+
+		Locale.setDefault(new Locale("de", "DE"));
+		view = new RemoteFSView();
+		RemoteFSView view = new RemoteFSView();
+		controller = (RemoteFSController) view.getPresenter();
 	}
 
 	@After
-	public void teadDown() throws Exception {
+	public void tearDown() throws Exception {
 		localWrite.delete(localStorageFile.getName());
 		FileUtils.deleteDirectory(new File(TEST_TMP_DIR));
 		FileUtils.deleteDirectory(new File(TMP_DIR + "/" + controller.ROOT_FOLDER_NAME));
@@ -107,17 +123,11 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 		return children;
 	}
 
-
 	@Test
 	public void injectlTest() {
-		Locale.setDefault(new Locale("de", "DE"));
-		RemoteFSView view = new RemoteFSView();
-		Identity i = new Identity("test", null, new QblECKeyPair());
-		clientConfiguration.selectIdentity(i);
-		clientConfiguration.setAccount(new Account("http://localhost:9696","user","auth"));
-		controller = (RemoteFSController) view.getPresenter();
 		assertThat(controller.getRessource().getLocale().getCountry(), is("DE"));
 		assertThat(controller.getRessource().getLocale().getLanguage(), is("de"));
+		assertThat(controller.loadManager, is(notNullValue()));
 	}
 
 	@Test(timeout=1000L)
@@ -190,34 +200,19 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 	}
 
 	@Test(timeout=1000L)
-	public void testUploadedDirectoryInRootNode() throws QblStorageException, IOException {
-
-		initTreeTable();
-		assertThat(controller.nav.listFolders().size(), is(1));
-		assertThat(controller.nav.listFiles().size(), is(0));
-
-		BoxFolder folder = controller.nav.listFolders().get(0);
-		BoxNavigation newNav = nav.navigate(folder);
-
-		assertThat(newNav.listFiles().size(), is(1));
-		assertThat(newNav.listFolders().size(), is(1));
-	}
-
-	@Test(timeout=1000L)
-	public void testUploadedDirectoryInChildNode() throws QblStorageException, IOException {
-
+	public void testUploadedDirectoryInChildNode() throws Exception {
 		File dir = new File(TEST_TMP_DIR);
 		dir.mkdirs();
 		BoxFolder folder = createBoxFolder(dir);
 
 		File subdir = new File(dir, "subFolder");
 		subdir.mkdirs();
-		controller.uploadedDirectory(dir, folder);
+		controller.uploadDirectory(dir.toPath(), Paths.get("/" + TEST_FOLDER + "/subFolder"));
+		executeTransactions();
 
 		BoxNavigation newNav = nav.navigate(folder);
 		assertThat(newNav.listFiles().size(), is(0));
 		assertThat(newNav.listFolders().size(), is(1));
-
 	}
 
 	@Test(timeout=1000L)
@@ -233,146 +228,159 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 
 	}
 
-
 	@Test(timeout=1000L)
-	public void TestUploadFiles() throws QblStorageException, IOException {
+	public void testUploadFiles() throws QblStorageException, IOException, InterruptedException {
 		File dir = new File(TEST_TMP_DIR);
 		dir.mkdirs();
 		BoxFolder folder = createBoxFolder(dir);
 		File tmp = new File(dir, "tmp1.txt");
 		tmp.createNewFile();
-		controller.uploadFiles(tmp, folder);
+		controller.upload(tmp.toPath(), Paths.get("/", TEST_FOLDER, "/", "tmp1.txt"));
+
+		assertEquals(1, loadManager.getTransactions().size());
+		executeTransactions();
 		BoxNavigation newNav = nav.navigate(folder);
 		assertThat(newNav.listFiles().size(), is(1));
 		assertThat(newNav.listFolders().size(), is(0));
 
 	}
 
+	private void executeTransactions() throws InterruptedException {
+		while (!loadManager.getTransactions().isEmpty()) {
+			loadManager.next();
+		}
+	}
+
 	@Test(timeout=1000L)
-	public void TestDontDeleteBoxFolder() throws QblStorageException, IOException {
+	public void testDontDeleteBoxFolder() throws Exception {
 		initTreeTable();
 		BoxFolder folder = controller.nav.listFolders().get(0);
-		controller.deleteBoxObject(ButtonType.NO, folder, null);
+		controller.deleteBoxObject(ButtonType.NO, Paths.get("/", TEST_FOLDER), folder);
+		executeTransactions();
+
 		assertThat(controller.nav.listFolders().size(), is(1));
 		assertThat(controller.nav.listFiles().size(), is(0));
 	}
 
 	@Test(timeout=1000L)
-	public void TestDeleteBoxFolder() throws QblStorageException, IOException {
+	public void testDeleteBoxFolder() throws Exception {
 		initTreeTable();
 
-		BoxFolder folder = controller.nav.listFolders().get(0);
-		controller.deleteBoxObject(ButtonType.OK, folder, null);
+		BoxFolder folder = nav.listFolders().get(0);
+		controller.deleteBoxObject(ButtonType.OK, Paths.get("/", TEST_FOLDER), folder);
+		executeTransactions();
+
 		assertThat(controller.nav.listFolders().size(), is(0));
 		assertThat(controller.nav.listFiles().size(), is(0));
 	}
 
 	@Test(timeout=1000L)
-	public void TestDeleteBoxFile() throws QblStorageException, IOException {
+	public void testDeleteBoxFile() throws Exception {
 		initTreeTable();
 
 		BoxFolder folder = nav.listFolders().get(0);
+		BoxFile file = nav.navigate(folder).listFiles().get(0);
+
+		controller.deleteBoxObject(ButtonType.OK, Paths.get("/", TEST_FOLDER, SUB_FILE), file);
+		executeTransactions();
 
 		BoxNavigation newNav = nav.navigate(folder);
-		BoxObject boxFile = newNav.listFiles().get(0);
-		controller.deleteBoxObject(ButtonType.OK, boxFile, folder);
-
-		newNav = nav.navigate(folder);
 		assertThat(newNav.listFiles().size(), is(0));
 	}
 
 	@Test(timeout=1000L)
-	public void TestDeleteBoxFileFromRootNode() throws QblStorageException, IOException {
+	public void testDeleteBoxFileFromRootNode() throws QblStorageException, IOException {
 		initTreeTable();
 		BoxFolder folder = nav.listFolders().get(0);
-		controller.deleteBoxObject(ButtonType.OK, folder, null);
+		controller.deleteBoxObject(ButtonType.OK, Paths.get("/", TEST_FOLDER), folder);
 		assertThat(nav.listFiles().size(), is(0));
 	}
 
 	@Test(timeout=1000L)
-	public void TestDownloadFolderFromRootNode() throws QblStorageException, IOException {
-		initTreeTable();
-		BoxFolder folder = nav.listFolders().get(0);
-		controller.downloadBoxObjectRootNode(folder, null, TMP_DIR);
+	public void testDownloadFolderFromRootNode() throws Exception {
+		BoxFolder folder = nav.createFolder("folder");
+		Path targetDir = Paths.get(TMP_DIR, "folder");
+		controller.downloadBoxObject(folder, nav.navigate("folder"), Paths.get("/folder"), targetDir);
+		executeTransactions();
 
-		File rootDir = new File(TMP_DIR + "/" + controller.ROOT_FOLDER_NAME);
-		File dir = new File(TMP_DIR + "/" +
-				controller.ROOT_FOLDER_NAME + "/" +
-				TEST_FOLDER);
-		File subDir = new File(TMP_DIR + "/" +
-				controller.ROOT_FOLDER_NAME + "/" +
-				TEST_FOLDER + "/" +
-				TEST_SUB_FOLDER
-		);
-
-		assertThat(TEST_SUB_FOLDER, is(subDir.getName()));
-		assertThat(controller.ROOT_FOLDER_NAME, is(rootDir.getName()));
-		assertThat(TEST_FOLDER, is(dir.getName()));
+		assertTrue(Files.isDirectory(targetDir));
 	}
 
-	@Test(timeout=1000L)
-	public void TestDownloadFolderFromNode() throws QblStorageException, IOException {
-		initTreeTable();
-		BoxFolder root = nav.listFolders().get(0);
-		BoxNavigation newNav = nav.navigate(root);
-		BoxFolder folder = newNav.listFolders().get(0);
-		controller.downloadBoxObject(folder, root, TEST_TMP_DIR);
+	@Test
+	public void testDownloadFolderFromNode() throws Exception {
+		BoxFolder node = nav.createFolder(TEST_FOLDER);
+		BoxNavigation nodeNav = nav.navigate(node);
+		BoxFolder folder = nodeNav.createFolder(TEST_SUB_FOLDER);
+		nodeNav.navigate(folder).upload(SUB_FILE, file);
+		Path targetFolder = tempFolder.resolve(folder.name);
+		controller.downloadBoxObject(folder, nodeNav.navigate(folder), Paths.get("/", node.name, folder.name), targetFolder);
+		executeTransactions();
 
-		File dir = new File(TEST_TMP_DIR);
-		File subDir = new File(TEST_TMP_DIR
-				+ "/" +
-				TEST_SUB_FOLDER
-		);
-
-		assertThat(TEST_FOLDER, is(dir.getName()));
-		assertThat(TEST_SUB_FOLDER, is(subDir.getName()));
+		assertTrue(Files.isDirectory(targetFolder));
+		Path filePath = targetFolder.resolve(SUB_FILE);
+		assertTrue(filePath.toString() + " has not been downloaded", Files.exists(filePath));
 	}
 
-	@Test(timeout=1000L)
-	public void TestDownloadFileFromRootNode() throws QblStorageException, IOException {
+	@Test
+	public void testRecursiveDownload() throws Exception {
+		BoxFolder node = nav.createFolder("folder");
+		nav.navigate("folder").createFolder("subfolder");
+		Path targetFolder = tempFolder.resolve("name");
+		controller.downloadBoxObject(node, nav.navigate("folder"), Paths.get("/folder"), targetFolder);
+		executeTransactions();
+
+		assertTrue(Files.isDirectory(targetFolder.resolve("subfolder")));
+	}
+
+	@Test
+	public void testDownloadFileFromRootNode() throws Exception {
 		controller.nav = nav;
 
 		File testDir = new File(TEST_TMP_DIR);
 		testDir.mkdirs();
 		File tmpFile = new File(testDir, SUB_FILE);
 		tmpFile.createNewFile();
-		controller.uploadFiles(tmpFile, null);
+		Path remotePath = Paths.get("/" + SUB_FILE);
+		controller.upload(tmpFile.toPath(), remotePath);
+		executeTransactions();
+
 		BoxFile file = nav.listFiles().get(0);
 
-		controller.downloadBoxObject(file, null, TMP_DIR);
+		controller.downloadBoxObject(file, nav, remotePath, Paths.get(TMP_DIR).resolve(file.name));
+		executeTransactions();
 		File testFile = new File(TMP_DIR + "/" + SUB_FILE);
 
-		assertThat(SUB_FILE, is(testFile.getName()));
-
-
+		assertTrue(testFile.exists());
 	}
 
 	@Test(timeout=1000L)
-	public void TestDownloadFileFromSubNode() throws QblStorageException, IOException {
+	public void testDownloadFileFromSubNode() throws Exception {
 		initTreeTable();
 
 		BoxFolder root = nav.listFolders().get(0);
 		BoxNavigation newNav = nav.navigate(root);
 		BoxFile file = newNav.listFiles().get(0);
 
-		controller.downloadBoxObject(file, root, TMP_DIR);
+		controller.downloadBoxObject(file, newNav, Paths.get("/", TEST_FOLDER, "/", SUB_FILE), Paths.get(TMP_DIR).resolve(SUB_FILE));
+		executeTransactions();
 		File testFile = new File(TMP_DIR + "/" + SUB_FILE);
-		assertThat(SUB_FILE, is(testFile.getName()));
+		assertTrue(testFile.exists());
 	}
 
-	private void initTreeTable() throws IOException {
-		File dir = craeteFileAndFolder();
-		controller.nav = nav;
-		controller.uploadedDirectory(dir, null);
+	private void initTreeTable() throws IOException, QblStorageException {
+		createFileAndFolder();
+		BoxFolder folder = nav.createFolder(TEST_FOLDER);
+		nav.navigate(folder).upload(SUB_FILE, new File(TEST_TMP_DIR, SUB_FILE));
+		nav.navigate(folder).createFolder(TEST_SUB_FOLDER);
 	}
 
 	private BoxFolder createBoxFolder(File dir) throws QblStorageException {
 		controller.nav = nav;
-		controller.uploadedDirectory(dir, null);
+		nav.createFolder(dir.getName());
 		return controller.nav.listFolders().get(0);
 	}
 
-	private File craeteFileAndFolder() throws IOException {
+	private File createFileAndFolder() throws IOException {
 		File dir = new File(TEST_TMP_DIR);
 		dir.mkdirs();
 		File tmp = new File(dir, SUB_FILE);

--- a/src/test/java/de/qabel/desktop/ui/remotefs/RemoteFSControllerTest.java
+++ b/src/test/java/de/qabel/desktop/ui/remotefs/RemoteFSControllerTest.java
@@ -206,13 +206,16 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 		BoxFolder folder = createBoxFolder(dir);
 
 		File subdir = new File(dir, "subFolder");
-		subdir.mkdirs();
-		controller.uploadDirectory(dir.toPath(), Paths.get("/" + TEST_FOLDER + "/subFolder"));
+		new File(subdir, "subsubFolder").mkdirs();
+		new File(subdir, "subsubFile").createNewFile();
+		controller.uploadDirectory(dir.toPath(), Paths.get("/", TEST_FOLDER));
 		executeTransactions();
 
 		BoxNavigation newNav = nav.navigate(folder);
 		assertThat(newNav.listFiles().size(), is(0));
 		assertThat(newNav.listFolders().size(), is(1));
+		assertThat(newNav.navigate("subFolder").listFolders().get(0).name, is("subsubFolder"));
+		assertThat(newNav.navigate("subFolder").listFiles().get(0).name, is("subsubFile"));
 	}
 
 	@Test(timeout=1000L)
@@ -303,7 +306,7 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 		controller.downloadBoxObject(folder, nav.navigate("folder"), Paths.get("/folder"), targetDir);
 		executeTransactions();
 
-		assertTrue(Files.isDirectory(targetDir));
+		assertTrue("folder was not downloaded", Files.isDirectory(targetDir));
 	}
 
 	@Test
@@ -313,7 +316,7 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 		BoxFolder folder = nodeNav.createFolder(TEST_SUB_FOLDER);
 		nodeNav.navigate(folder).upload(SUB_FILE, file);
 		Path targetFolder = tempFolder.resolve(folder.name);
-		controller.downloadBoxObject(folder, nodeNav.navigate(folder), Paths.get("/", node.name, folder.name), targetFolder);
+		controller.downloadBoxObject(folder, nodeNav.navigate(folder), Paths.get("/", node.name, folder.name), tempFolder);
 		executeTransactions();
 
 		assertTrue(Files.isDirectory(targetFolder));
@@ -325,8 +328,8 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 	public void testRecursiveDownload() throws Exception {
 		BoxFolder node = nav.createFolder("folder");
 		nav.navigate("folder").createFolder("subfolder");
-		Path targetFolder = tempFolder.resolve("name");
-		controller.downloadBoxObject(node, nav.navigate("folder"), Paths.get("/folder"), targetFolder);
+		Path targetFolder = tempFolder.resolve("folder");
+		controller.downloadBoxObject(node, nav.navigate("folder"), Paths.get("/folder"), tempFolder);
 		executeTransactions();
 
 		assertTrue(Files.isDirectory(targetFolder.resolve("subfolder")));
@@ -346,7 +349,7 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 
 		BoxFile file = nav.listFiles().get(0);
 
-		controller.downloadBoxObject(file, nav, remotePath, Paths.get(TMP_DIR).resolve(file.name));
+		controller.downloadBoxObject(file, nav, remotePath, Paths.get(TMP_DIR));
 		executeTransactions();
 		File testFile = new File(TMP_DIR + "/" + SUB_FILE);
 
@@ -361,7 +364,7 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 		BoxNavigation newNav = nav.navigate(root);
 		BoxFile file = newNav.listFiles().get(0);
 
-		controller.downloadBoxObject(file, newNav, Paths.get("/", TEST_FOLDER, "/", SUB_FILE), Paths.get(TMP_DIR).resolve(SUB_FILE));
+		controller.downloadBoxObject(file, newNav, Paths.get("/", TEST_FOLDER, "/", SUB_FILE), Paths.get(TMP_DIR));
 		executeTransactions();
 		File testFile = new File(TMP_DIR + "/" + SUB_FILE);
 		assertTrue(testFile.exists());

--- a/src/test/java/de/qabel/desktop/ui/remotefs/RemoteFSControllerTest.java
+++ b/src/test/java/de/qabel/desktop/ui/remotefs/RemoteFSControllerTest.java
@@ -219,12 +219,14 @@ public class RemoteFSControllerTest extends AbstractControllerTest {
 	}
 
 	@Test(timeout=1000L)
-	public void testCreateFolder() throws QblStorageException {
+	public void testCreateFolder() throws Exception {
 
 		File dir = new File(TEST_TMP_DIR);
 		dir.mkdirs();
 		BoxFolder folder = createBoxFolder(dir);
-		controller.createFolder("NewFolder", folder);
+		controller.createFolder(Paths.get("/", TEST_FOLDER, dir.getName()));
+		executeTransactions();
+
 		BoxNavigation newNav = nav.navigate(folder);
 		assertThat(newNav.listFiles().size(), is(0));
 		assertThat(newNav.listFolders().size(), is(1));


### PR DESCRIPTION
some polishing:
 * RemoteFS browser now uses async transfers (up- / download)
 * sync operations (changes to local or remote fs) trigger UI updates
 * RemoteFS browser now only updates the contents of the changed folder
 * polling uses Last-Modified headers (reduces traffic by > 99%) #111
 * uploads set the correct mtime (same as the local file had) to reduce sync problems
 * added a prototype progress bar (not wirking very well on uploads because the S3client contains the full stream before even starting the upload but at least you can tell if the application is doing stuff)