### PR TITLE
#120 store tmp download in same dir as target file

### DIFF
--- a/src/main/java/de/qabel/desktop/DesktopClient.java
+++ b/src/main/java/de/qabel/desktop/DesktopClient.java
@@ -201,7 +201,7 @@ public class DesktopClient extends Application {
 		});
 	}
 
-	protected SyncDaemon getSyncDaemon(ClientConfiguration config) {
+	protected SyncDaemon getSyncDaemon(ClientConfiguration config) throws IOException {
 		new Thread(transferManager, "TransactionManager").start();
 		return new SyncDaemon(config.getBoxSyncConfigs(), new DefaultSyncerFactory(boxVolumeFactory, transferManager));
 	}

--- a/src/main/java/de/qabel/desktop/daemon/management/DefaultTransferManager.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/DefaultTransferManager.java
@@ -159,7 +159,8 @@ public class DefaultTransferManager extends Observable implements TransferManage
 
 	private Path createTempFileForDownload(Path destinationFile) throws IOException {
 		String filename = destinationFile.getFileName().toString();
-		return destinationFile.getParent().resolve("." + filename + ".qpart~");
+		Path tmpFile = destinationFile.getParent().resolve("." + filename + ".qpart~");
+		return tmpFile;
 	}
 
 	private boolean localIsNewer(Path local, BoxFile file) {

--- a/src/main/java/de/qabel/desktop/daemon/management/DefaultTransferManager.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/DefaultTransferManager.java
@@ -126,14 +126,17 @@ public class DefaultTransferManager extends Observable implements TransferManage
 
 					ProgressListener listener = new TransactionRelatedProgressListener(download);
 					try (InputStream stream = new BufferedInputStream(nav.download(file, listener))) {
-						Path tmpFile = Files.createTempFile("prefix", "suffix");
-						Files.copy(stream, tmpFile, StandardCopyOption.REPLACE_EXISTING);
-						Files.setLastModifiedTime(tmpFile, FileTime.fromMillis(download.getMtime()));
-						Files.move(tmpFile, destination, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-						if (Files.getLastModifiedTime(destination).toMillis() != download.getMtime()) {
-							Files.setLastModifiedTime(destination, FileTime.fromMillis(download.getMtime()));
+						Path tmpFile = createTempFileForDownload(destination);
+						try {
+							Files.copy(stream, tmpFile, StandardCopyOption.REPLACE_EXISTING);
+							Files.setLastModifiedTime(tmpFile, FileTime.fromMillis(download.getMtime()));
+							Files.move(tmpFile, destination, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+							if (Files.getLastModifiedTime(destination).toMillis() != download.getMtime()) {
+								Files.setLastModifiedTime(destination, FileTime.fromMillis(download.getMtime()));
+							}
+						} finally {
+							Files.deleteIfExists(tmpFile);
 						}
-						Files.deleteIfExists(tmpFile);
 					}
 					break;
 				case DELETE:
@@ -152,6 +155,11 @@ public class DefaultTransferManager extends Observable implements TransferManage
 			download.toState(FAILED);
 			throw e;
 		}
+	}
+
+	private Path createTempFileForDownload(Path destinationFile) throws IOException {
+		String filename = destinationFile.getFileName().toString();
+		return destinationFile.getParent().resolve("." + filename + ".qpart~");
 	}
 
 	private boolean localIsNewer(Path local, BoxFile file) {

--- a/src/main/java/de/qabel/desktop/daemon/sync/blacklist/Blacklist.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/blacklist/Blacklist.java
@@ -1,0 +1,13 @@
+package de.qabel.desktop.daemon.sync.blacklist;
+
+public interface Blacklist {
+	/**
+	 * returns true if the given filename is blacklisted by this blacklist.
+	 * Whether it matches a list of strings or patterns or whatever metric is uses is
+	 * left open to the implementation.
+	 *
+	 * @param filename to check
+	 * @return true if the filename is blacklisted
+	 */
+	boolean matches(String filename);
+}

--- a/src/main/java/de/qabel/desktop/daemon/sync/blacklist/FileBasedSyncBlacklist.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/blacklist/FileBasedSyncBlacklist.java
@@ -1,0 +1,31 @@
+package de.qabel.desktop.daemon.sync.blacklist;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+public class FileBasedSyncBlacklist extends PatternBlacklist {
+	private static final Logger logger = LoggerFactory.getLogger(FileBasedSyncBlacklist.class.getSimpleName());
+	private static final Pattern TMP_DOWNLOAD_PATTERN = Pattern.compile("\\..*\\.qpart~");
+
+	public FileBasedSyncBlacklist(Path patterns) throws IOException {
+		add(TMP_DOWNLOAD_PATTERN);
+		for (String line : Files.readAllLines(patterns)) {
+			try {
+				line = line.trim();
+				if (line.isEmpty()) {
+					continue;
+				}
+
+				add(Pattern.compile(line));
+			} catch (PatternSyntaxException e) {
+				logger.warn("failed to load blacklist pattern: '" + line + "' (" + e.getMessage() + ")", e);
+			}
+		}
+	}
+}

--- a/src/main/java/de/qabel/desktop/daemon/sync/blacklist/FileBasedSyncBlacklist.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/blacklist/FileBasedSyncBlacklist.java
@@ -3,7 +3,10 @@ package de.qabel.desktop.daemon.sync.blacklist;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
@@ -16,16 +19,29 @@ public class FileBasedSyncBlacklist extends PatternBlacklist {
 	public FileBasedSyncBlacklist(Path patterns) throws IOException {
 		add(TMP_DOWNLOAD_PATTERN);
 		for (String line : Files.readAllLines(patterns)) {
-			try {
-				line = line.trim();
-				if (line.isEmpty()) {
-					continue;
-				}
+			addLine(line);
+		}
+	}
 
-				add(Pattern.compile(line));
-			} catch (PatternSyntaxException e) {
-				logger.warn("failed to load blacklist pattern: '" + line + "' (" + e.getMessage() + ")", e);
+	public FileBasedSyncBlacklist(InputStream patternStream) throws IOException {
+		add(TMP_DOWNLOAD_PATTERN);
+		BufferedReader reader = new BufferedReader(new InputStreamReader(patternStream));
+		String line;
+		while ((line = reader.readLine()) != null) {
+			addLine(line);
+		}
+	}
+
+	private void addLine(String line) {
+		try {
+			line = line.trim();
+			if (line.isEmpty()) {
+				return;
 			}
+
+			add(Pattern.compile(line));
+		} catch (PatternSyntaxException e) {
+			logger.warn("failed to load blacklist pattern: '" + line + "' (" + e.getMessage() + ")", e);
 		}
 	}
 }

--- a/src/main/java/de/qabel/desktop/daemon/sync/blacklist/PatternBlacklist.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/blacklist/PatternBlacklist.java
@@ -1,0 +1,23 @@
+package de.qabel.desktop.daemon.sync.blacklist;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class PatternBlacklist implements Blacklist {
+	private List<Pattern> patterns = new LinkedList<>();
+
+	@Override
+	public boolean matches(String filename) {
+		for (Pattern pattern : patterns) {
+			if (pattern.matcher(filename).matches()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public void add(Pattern pattern) {
+		patterns.add(pattern);
+	}
+}

--- a/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerFactory.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerFactory.java
@@ -4,24 +4,32 @@ import de.qabel.desktop.config.BoxSyncConfig;
 import de.qabel.desktop.config.factory.BoxVolumeFactory;
 import de.qabel.desktop.daemon.management.MonitoredTransferManager;
 import de.qabel.desktop.daemon.management.TransferManager;
+import de.qabel.desktop.daemon.sync.blacklist.Blacklist;
+import de.qabel.desktop.daemon.sync.blacklist.FileBasedSyncBlacklist;
 import de.qabel.desktop.storage.cache.CachedBoxVolume;
+
+import java.io.IOException;
 
 public class DefaultSyncerFactory implements SyncerFactory {
 	private TransferManager manager;
 
 	private BoxVolumeFactory boxVolumeFactory;
+	private final Blacklist blacklist;
 
-	public DefaultSyncerFactory(BoxVolumeFactory boxVolumeFactory, TransferManager manager) {
+	public DefaultSyncerFactory(BoxVolumeFactory boxVolumeFactory, TransferManager manager) throws IOException {
 		this.boxVolumeFactory = boxVolumeFactory;
 		this.manager = manager;
+		blacklist = new FileBasedSyncBlacklist(getClass().getResourceAsStream("/ignore"));
 	}
 
 	@Override
 	public Syncer factory(BoxSyncConfig config) {
-		return new DefaultSyncer(
+		DefaultSyncer syncer = new DefaultSyncer(
 				config,
 				(CachedBoxVolume) boxVolumeFactory.getVolume(config.getAccount(), config.getIdentity()),
 				manager
 		);
+		syncer.setLocalBlacklist(blacklist);
+		return syncer;
 	}
 }

--- a/src/main/java/de/qabel/desktop/daemon/sync/worker/TreeWatcher.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/worker/TreeWatcher.java
@@ -80,11 +80,11 @@ public class TreeWatcher extends Thread {
 				Path child = parent.resolve(name);
 
 				boolean isDir = Files.isDirectory(child);
-				long mtime = Files.getLastModifiedTime(child).toMillis();
 				ChangeEvent ce;
 				if (kind == ENTRY_DELETE) {
 					ce = new LocalDeleteEvent(child, isDir, System.currentTimeMillis(), convertType(kind));
 				} else {
+					long mtime = Files.getLastModifiedTime(child).toMillis();
 					ce = new LocalChangeEvent(child, isDir, mtime, convertType(kind));
 				}
 				consumer.accept(ce);

--- a/src/main/resources/ignore
+++ b/src/main/resources/ignore
@@ -1,0 +1,2 @@
+.*~
+desktop\.ini

--- a/src/test/java/de/qabel/desktop/daemon/sync/blacklist/FileBasedSyncBlacklistTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/blacklist/FileBasedSyncBlacklistTest.java
@@ -1,0 +1,27 @@
+package de.qabel.desktop.daemon.sync.blacklist;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+import static org.junit.Assert.*;
+
+public class FileBasedSyncBlacklistTest {
+	private Blacklist blacklist;
+
+	@Before
+	public void setUp() throws Exception {
+		blacklist = new FileBasedSyncBlacklist(Paths.get(getClass().getResource("/ignore").toURI()));
+	}
+
+	@Test
+	public void testExcludesDownload() {
+		assertTrue(blacklist.matches(".mydoc.docx.qpart~"));
+	}
+
+	@Test
+	public void testDoesNotExcludeNormalWordDocument() {
+		assertFalse(blacklist.matches("mydoc.docx"));
+	}
+}

--- a/src/test/java/de/qabel/desktop/daemon/sync/blacklist/PatternBlacklistTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/blacklist/PatternBlacklistTest.java
@@ -1,0 +1,42 @@
+package de.qabel.desktop.daemon.sync.blacklist;
+
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+public class PatternBlacklistTest {
+	private PatternBlacklist blacklist = new PatternBlacklist();
+
+	@Test
+	public void doesntMatchWithoutPattern() {
+		assertFalse(blacklist.matches("filename"));
+	}
+
+	@Test
+	public void doesMatchWithMatchingPattern() {
+		blacklist.add(Pattern.compile(".*"));
+		assertTrue(blacklist.matches("filename"));
+	}
+
+	@Test
+	public void matchesIfAtLeastOnePatternMatches() {
+		blacklist.add(Pattern.compile("doesntmatch"));
+		blacklist.add(Pattern.compile("f.*"));
+		assertTrue(blacklist.matches("filename"));
+	}
+
+	@Test
+	public void doesntMatchIfNotWhileStringMatches() {
+		blacklist.add(Pattern.compile("[0-9]+"));
+		assertFalse(blacklist.matches("f0"));
+	}
+
+	@Test
+	public void matchesIfAtLeastFirstPatternMatches() {
+		blacklist.add(Pattern.compile("f.*"));
+		blacklist.add(Pattern.compile("doesntmatch"));
+		assertTrue(blacklist.matches("filename"));
+	}
+}

--- a/src/test/java/de/qabel/desktop/daemon/sync/worker/BlacklistSpy.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/worker/BlacklistSpy.java
@@ -1,0 +1,26 @@
+package de.qabel.desktop.daemon.sync.worker;
+
+import de.qabel.desktop.daemon.sync.blacklist.Blacklist;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class BlacklistSpy implements Blacklist {
+	private Blacklist blacklist;
+	public List<String> tests = new LinkedList<>();
+	public int matches = 0;
+
+	public BlacklistSpy(Blacklist blacklist) {
+		this.blacklist = blacklist;
+	}
+
+	@Override
+	public boolean matches(String filename) {
+		tests.add(filename);
+		boolean match = blacklist.matches(filename);
+		if (match) {
+			++matches;
+		}
+		return match;
+	}
+}

--- a/src/test/java/de/qabel/desktop/daemon/sync/worker/TreeWatcherTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/worker/TreeWatcherTest.java
@@ -117,6 +117,20 @@ public class TreeWatcherTest extends AbstractSyncTest {
 		assertEquals(getPath("/existingSubdir"), events.get(2).getPath());
 	}
 
+	@Test(timeout = 10000L)
+	public void notifiesAboutFileDeletes() throws Exception {
+		File file = new File(tmpDir.toFile(), "existingFile");
+		file.createNewFile();
+		watch();
+
+		waitUntil(() -> events.size() == 2);
+		events.clear();
+
+		file.delete();
+		waitUntil(() -> events.size() == 1);
+		assertEquals(getPath("/existingFile"), events.get(0).getPath());
+	}
+
 	protected void watch() {
 		watcher.start();
 		waitUntil(watcher::isWatching);

--- a/start-servers.sh
+++ b/start-servers.sh
@@ -17,7 +17,7 @@ function waitForPort {
     fi
 }
 
-DIRHASH=$(`pwd` | shasum | cut -d" " -f1)
+DIRHASH=$(pwd | shasum | cut -d" " -f1)
 
 # qabel-drop
 cd qabel-drop


### PR DESCRIPTION
Actually, the real (encrypted) download still happens to the global tmp dir. Only the decrypted file is fetched to the target directory and then atomically moved to the target position.

Additionally, we now have a file pattern blacklist. Patterns at `src/main/resources/ignore` are not uploaded at all.

Don't know how to test the tmp-file part, but the blacklist should be well tested.