### PR TITLE
part of #182, stop syncer cleanly

### DIFF
--- a/src/main/java/de/qabel/desktop/daemon/management/DefaultTransferManager.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/DefaultTransferManager.java
@@ -48,6 +48,20 @@ public class DefaultTransferManager extends Observable implements TransferManage
 	}
 
 	@Override
+	public void cleanup() {
+		synchronized (transactions) {
+			Iterator<Transaction> iter = transactions.iterator();
+			Transaction transaction;
+			while (iter.hasNext()) {
+				transaction = iter.next();
+				if (transaction.isDone() || !transaction.isValid()) {
+					iter.remove();
+				}
+			}
+		}
+	}
+
+	@Override
 	public void addUpload(Upload upload) {
 		logger.trace("upload added: " + upload.getSource() + " to " + upload.getDestination());
 		transactions.add(upload);

--- a/src/main/java/de/qabel/desktop/daemon/management/MonitoredTransferManager.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/MonitoredTransferManager.java
@@ -39,6 +39,11 @@ public class MonitoredTransferManager implements TransferManager {
 	}
 
 	@Override
+	public void cleanup() {
+		manager.cleanup();
+	}
+
+	@Override
 	public void run() {
 		manager.run();
 	}

--- a/src/main/java/de/qabel/desktop/daemon/management/TransactionGroup.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/TransactionGroup.java
@@ -52,4 +52,15 @@ public class TransactionGroup extends Observable implements Observer, HasProgres
 		setChanged();
 		notifyObservers(transaction);
 	}
+
+	public void cancel() {
+		synchronized (transactions) {
+			for (Transaction t: transactions.toArray(new Transaction[0])) {
+				if (t.isDone()) {
+					continue;
+				}
+				t.toState(Transaction.STATE.FAILED);
+			}
+		}
+	}
 }

--- a/src/main/java/de/qabel/desktop/daemon/management/TransferManager.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/TransferManager.java
@@ -8,4 +8,9 @@ public interface TransferManager extends Runnable {
 	void addUpload(Upload upload);
 	void addDownload(Download download);
 	List<Transaction> getHistory();
+
+	/**
+	 * removes Transactions that are no longer valid or cancelled
+	 */
+	void cleanup();
 }

--- a/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
@@ -299,6 +299,7 @@ public class DefaultSyncer implements Syncer, BoxSync, HasProgress {
 		poller.interrupt();
 		watcher.join();
 		poller.join();
+		progress.cancel();
 	}
 
 	public boolean isPolling() {

--- a/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
@@ -79,7 +79,7 @@ public class DefaultSyncer implements Syncer, BoxSync, HasProgress {
 						nav.refresh();
 						polling = true;
 					} catch (QblStorageException e) {
-						e.printStackTrace();
+						logger.warn("polling failed: " + e.getMessage(), e);
 					}
 					Thread.sleep(pollUnit.toMillis(pollInterval));
 				}
@@ -296,7 +296,9 @@ public class DefaultSyncer implements Syncer, BoxSync, HasProgress {
 	@Override
 	public void stop() throws InterruptedException {
 		watcher.interrupt();
+		poller.interrupt();
 		watcher.join();
+		poller.join();
 	}
 
 	public boolean isPolling() {

--- a/src/test-gui/java/de/qabel/desktop/ui/AbstractPage.java
+++ b/src/test-gui/java/de/qabel/desktop/ui/AbstractPage.java
@@ -77,12 +77,15 @@ public class AbstractPage {
 		Node[] nodes = new Node[1];
 		waitUntil(() -> {
 			Optional<Node> node = robot.lookup(query).tryQueryFirst();
-			boolean present = node.isPresent();
+			boolean present = node.isPresent() && node.get() != null;
 			if (present) {
 				nodes[0] = node.get();
 			}
 			return present;
 		});
+		if (nodes[0] == null) {
+			throw new IllegalStateException("node should be present but is null: " + query);
+		}
 		return nodes[0];
 	}
 

--- a/src/test/java/de/qabel/desktop/daemon/management/TransferManagerStub.java
+++ b/src/test/java/de/qabel/desktop/daemon/management/TransferManagerStub.java
@@ -28,6 +28,11 @@ public class TransferManagerStub implements TransferManager {
 	}
 
 	@Override
+	public void cleanup() {
+
+	}
+
+	@Override
 	public void run() {
 		hasRun = true;
 	}

--- a/src/test/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerTest.java
@@ -90,13 +90,24 @@ public class DefaultSyncerTest extends AbstractSyncTest {
 	}
 
 	@Test
-	public void stopStoppsPolling() throws Exception {
+	public void stopStopsPolling() throws Exception {
 		syncer = new DefaultSyncer(config, new BoxVolumeStub(), manager);
 		syncer.run();
 
 		waitUntil(() -> manager.getTransactions().size() == 1 && syncer.isPolling());
 		syncer.stop();
 		assertFalse(syncer.isPolling());
+	}
+
+	@Test
+	public void stopStopsTransactions() throws Exception {
+		syncer = new DefaultSyncer(config, new BoxVolumeStub(), manager);
+		syncer.run();
+
+		waitUntil(() -> manager.getTransactions().size() == 1);
+		syncer.stop();
+		manager.cleanup();
+		assertEquals(0, manager.getTransactions().size());
 	}
 
 	@Test

--- a/src/test/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerTest.java
@@ -90,6 +90,16 @@ public class DefaultSyncerTest extends AbstractSyncTest {
 	}
 
 	@Test
+	public void stopStoppsPolling() throws Exception {
+		syncer = new DefaultSyncer(config, new BoxVolumeStub(), manager);
+		syncer.run();
+
+		waitUntil(() -> manager.getTransactions().size() == 1 && syncer.isPolling());
+		syncer.stop();
+		assertFalse(syncer.isPolling());
+	}
+
+	@Test
 	public void addsFoldersAsDownloads() throws Exception {
 		BoxNavigationStub nav = new BoxNavigationStub(null, null);
 		nav.event = new RemoteChangeEvent(Paths.get("/tmp/someFolder"), true, 1000L, ChangeEvent.TYPE.CREATE, null, nav);


### PR DESCRIPTION
To be able to delete syncs ( #182 ) we need to be able to even stop them cleanly.
This PR adds functionality to stop remote polling and pending transfer of syncs when the sync ist stopped. The removal of local notifications was contained in https://github.com/Qabel/qabel-desktop/pull/303