### PR TITLE
[UX] fixed full sync stop on delete

### DIFF
--- a/src/main/java/de/qabel/desktop/daemon/management/DefaultTransferManager.java
+++ b/src/main/java/de/qabel/desktop/daemon/management/DefaultTransferManager.java
@@ -44,7 +44,7 @@ public class DefaultTransferManager extends Observable implements TransferManage
 
     @Override
     public List<Transaction> getHistory() {
-        return Collections.unmodifiableList(history);
+        return history;
     }
 
     @Override
@@ -81,6 +81,10 @@ public class DefaultTransferManager extends Observable implements TransferManage
 
     public void next() throws InterruptedException {
         Transaction transaction = transactions.take();
+        if (transaction.isDone()) {
+            return;
+        }
+
         transaction.toState(WAITING);
         setChanged();
         notifyObservers(transaction);

--- a/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
@@ -38,7 +38,7 @@ import static de.qabel.desktop.daemon.management.Transaction.TYPE.*;
 import static de.qabel.desktop.daemon.sync.event.ChangeEvent.TYPE.UPDATE;
 
 public class DefaultSyncer implements Syncer {
-    private static final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private ExecutorService executor;
     private static final ExecutorService fileExecutor = Executors.newSingleThreadExecutor();
     private BoxSyncBasedUploadFactory uploadFactory = new BoxSyncBasedUploadFactory();
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -50,17 +50,17 @@ public class DefaultSyncer implements Syncer {
     private Thread poller;
     private TreeWatcher watcher;
     private boolean polling;
-    private final SyncIndex index;
+    private SyncIndex index;
     private WindowedTransactionGroup progress = new WindowedTransactionGroup();
     private List<Transaction> history = new LinkedList<>();
     private Blacklist localBlacklist;
     private Observer remoteChangeHandler;
+    private CachedBoxNavigation nav;
 
     public DefaultSyncer(BoxSyncConfig config, CachedBoxVolume boxVolume, TransferManager manager) {
         this.config = config;
         this.boxVolume = boxVolume;
         this.manager = manager;
-        index = config.getSyncIndex();
         config.setSyncer(this);
     }
 
@@ -76,6 +76,10 @@ public class DefaultSyncer implements Syncer {
     @Override
     public void run() {
         try {
+            executor = Executors.newFixedThreadPool(10);
+            ensureLocalDir();
+            index = config.getSyncIndex();
+
             startWatcher();
             registerRemoteChangeHandler();
             registerRemotePoller();
@@ -112,7 +116,7 @@ public class DefaultSyncer implements Syncer {
     }
 
     protected void registerRemoteChangeHandler() throws QblStorageException {
-        CachedBoxNavigation nav = navigateToRemoteDir();
+        nav = navigateToRemoteDir();
 
         remoteChangeHandler = (o, arg) -> executor.submit(() -> {
             try {
@@ -283,13 +287,7 @@ public class DefaultSyncer implements Syncer {
     }
 
     protected void startWatcher() throws IOException {
-        Path localPath = config.getLocalPath();
-        if (!Files.isDirectory(localPath)) {
-            Files.createDirectories(localPath);
-        }
-        if (!Files.isReadable(localPath)) {
-            throw new IllegalStateException("local dir " + localPath + " is not valid");
-        }
+        Path localPath = ensureLocalDir();
         watcher = new TreeWatcher(localPath, watchEvent -> {
             try {
                 synchronized (this) {
@@ -314,20 +312,32 @@ public class DefaultSyncer implements Syncer {
         watcher.start();
     }
 
+    private Path ensureLocalDir() throws IOException {
+        Path localPath = config.getLocalPath();
+        if (!Files.isDirectory(localPath)) {
+            Files.createDirectories(localPath);
+        }
+        if (!Files.isReadable(localPath)) {
+            throw new IllegalStateException("local dir " + localPath + " is not valid");
+        }
+        return localPath;
+    }
+
     @Override
     public void shutdown() {
-        if (watcher != null && watcher.isAlive()) {
-            watcher.interrupt();
-        }
-        if (poller != null && poller.isAlive()) {
-            poller.interrupt();
-        }
+        interrupt();
         progress.cancel();
     }
 
     public void join() throws InterruptedException {
+        logger.trace("waiting for watcher");
         watcher.join();
+        logger.trace("waiting for poller");
         poller.join();
+        logger.trace("waiting for background tasks of sync");
+        if (!executor.isShutdown()) {
+            executor.shutdownNow();
+        }
     }
 
     @Override
@@ -338,11 +348,24 @@ public class DefaultSyncer implements Syncer {
 
     @Override
     public void stop() throws InterruptedException {
-        watcher.interrupt();
-        poller.interrupt();
-        watcher.join();
-        poller.join();
+        interrupt();
+        join();
+        logger.trace("cancelling transfers");
         progress.cancel();
+    }
+
+    private void interrupt() {
+        logger.trace("stopping syncer for " + config.getName());
+        if (nav != null) {
+            nav.deleteObserver(remoteChangeHandler);
+        }
+        if (watcher != null && watcher.isAlive()) {
+            watcher.interrupt();
+        }
+        if (poller != null && poller.isAlive()) {
+            poller.interrupt();
+        }
+        executor.shutdown();
     }
 
     public boolean isPolling() {

--- a/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncer.java
@@ -6,6 +6,7 @@ import de.qabel.desktop.daemon.management.TransferManager;
 import de.qabel.desktop.config.BoxSyncConfig;
 import de.qabel.desktop.daemon.management.*;
 import de.qabel.desktop.daemon.sync.blacklist.Blacklist;
+import de.qabel.desktop.daemon.sync.blacklist.PatternBlacklist;
 import de.qabel.desktop.daemon.sync.event.ChangeEvent;
 import de.qabel.desktop.daemon.sync.event.LocalDeleteEvent;
 import de.qabel.desktop.daemon.sync.event.RemoteChangeEvent;
@@ -33,11 +34,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 
 import static de.qabel.desktop.daemon.management.Transaction.TYPE.*;
 import static de.qabel.desktop.daemon.sync.event.ChangeEvent.TYPE.UPDATE;
 
 public class DefaultSyncer implements Syncer {
+    private static final Pattern DEFAULT_BLACKLIST_PATTERN = Pattern.compile("\\..*~");
     private ExecutorService executor;
     private static final ExecutorService fileExecutor = Executors.newSingleThreadExecutor();
     private BoxSyncBasedUploadFactory uploadFactory = new BoxSyncBasedUploadFactory();
@@ -62,6 +65,9 @@ public class DefaultSyncer implements Syncer {
         this.boxVolume = boxVolume;
         this.manager = manager;
         config.setSyncer(this);
+        PatternBlacklist defaultBlacklist = new PatternBlacklist();
+        defaultBlacklist.add(DEFAULT_BLACKLIST_PATTERN);
+        localBlacklist = defaultBlacklist;
     }
 
     public void setLocalBlacklist(Blacklist blacklist) {

--- a/src/main/java/de/qabel/desktop/daemon/sync/worker/TreeWatcher.java
+++ b/src/main/java/de/qabel/desktop/daemon/sync/worker/TreeWatcher.java
@@ -63,6 +63,7 @@ public class TreeWatcher extends Thread {
             logger.error(e.getMessage(), e);
         } catch (InterruptedException e) {
             logger.warn(e.getMessage(), e);
+        } finally {
             unregisterKeys();
         }
     }

--- a/src/main/java/de/qabel/desktop/storage/cache/CachedBoxNavigation.java
+++ b/src/main/java/de/qabel/desktop/storage/cache/CachedBoxNavigation.java
@@ -256,6 +256,9 @@ public class CachedBoxNavigation<T extends BoxNavigation> extends Observable imp
         }
 
         for (BoxFolder folder : listFolders()) {
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
             try {
                 navigate(folder).refresh();
             } catch (QblStorageException e) {
@@ -333,6 +336,10 @@ public class CachedBoxNavigation<T extends BoxNavigation> extends Observable imp
     }
 
     public void notifyAllContents() throws QblStorageException {
+        if (Thread.currentThread().isInterrupted()) {
+            return;
+        }
+
         // TODO notify async and sync files first (better UX on files)
         for (BoxFolder folder : nav.listFolders()) {
             notify(folder, CREATE);

--- a/src/main/java/de/qabel/desktop/ui/AbstractController.java
+++ b/src/main/java/de/qabel/desktop/ui/AbstractController.java
@@ -52,6 +52,7 @@ public class AbstractController {
     protected void alert(String message, Exception e) {
         if (!Platform.isFxApplicationThread()) {
             Platform.runLater(() -> alert(message, e));
+            return;
         }
         LoggerFactory.getLogger(getClass()).error(message, e);
         e.printStackTrace();

--- a/src/test-gui/java/de/qabel/desktop/ui/AbstractControllerGUITest.java
+++ b/src/test-gui/java/de/qabel/desktop/ui/AbstractControllerGUITest.java
@@ -17,7 +17,7 @@ public class AbstractControllerGUITest extends AbstractGuiTest<AlertTestControll
     @Test
     public void
     testAlertDialog() throws Exception {
-        Platform.runLater(() -> controller.alert("some error message", new Exception("exceptionmessage")));
+        controller.alert("some error message", new Exception("exceptionmessage"));
         waitUntil(() -> controller.alert != null);
         waitUntil(() -> controller.alert.getExceptionLabel() != null);
         waitForNode(".feedback");

--- a/src/test/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerTest.java
@@ -8,11 +8,9 @@ import de.qabel.desktop.config.factory.DropUrlGenerator;
 import de.qabel.desktop.config.factory.IdentityBuilderFactory;
 import de.qabel.desktop.daemon.management.*;
 import de.qabel.desktop.daemon.sync.AbstractSyncTest;
-import de.qabel.desktop.daemon.sync.blacklist.Blacklist;
 import de.qabel.desktop.daemon.sync.blacklist.PatternBlacklist;
-import de.qabel.desktop.daemon.sync.event.ChangeEvent;
 import de.qabel.desktop.daemon.sync.event.RemoteChangeEvent;
-import de.qabel.desktop.daemon.sync.worker.index.memory.InMemorySyncIndexFactory;
+import de.qabel.desktop.daemon.sync.worker.index.sqlite.SqliteSyncIndexFactory;
 import de.qabel.desktop.nio.boxfs.BoxFileSystem;
 import de.qabel.desktop.storage.BoxFile;
 import org.apache.commons.io.FileUtils;
@@ -60,7 +58,7 @@ public class DefaultSyncerTest extends AbstractSyncTest {
             BoxFileSystem.get("/"),
             identity,
             account,
-            new InMemorySyncIndexFactory()
+            new SqliteSyncIndexFactory()
         );
     }
 
@@ -81,6 +79,16 @@ public class DefaultSyncerTest extends AbstractSyncTest {
         syncer.run();
 
         waitUntil(() -> manager.getTransactions().size() == 2);
+    }
+
+    @Test
+    public void createsLocalDirIfNotExisting() throws Exception {
+        Path newDir = tmpDir.resolve("subdir");
+        config.setLocalPath(newDir);
+        syncer = new DefaultSyncer(config, new BoxVolumeStub(), manager);
+        syncer.run();
+
+        waitUntil(() -> Files.isDirectory(newDir));
     }
 
     @Test

--- a/src/test/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerTest.java
+++ b/src/test/java/de/qabel/desktop/daemon/sync/worker/DefaultSyncerTest.java
@@ -140,7 +140,7 @@ public class DefaultSyncerTest extends AbstractSyncTest {
         syncer = new DefaultSyncer(config, new BoxVolumeStub(), manager);
         syncer.run();
 
-        waitUntil(() -> manager.getTransactions().size() == 1);
+        waitUntil(() -> manager.getTransactions().size() == 1, () -> manager.getTransactions().toString());
         syncer.stop();
         manager.cleanup();
         assertEquals(0, manager.getTransactions().size());

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -12,10 +12,6 @@
         </Console>
     </Appenders>
     <Loggers>
-        <logger name="de.qabel.desktop.daemon" includeLocation="true">
-            <level>TRACE</level>
-            <AppenderRef ref="Console"/>
-        </logger>
         <logger name="de.qabel.desktop" includeLocation="true">
             <level>TRACE</level>
             <AppenderRef ref="Console"/>


### PR DESCRIPTION
When stopping a sync currently running, the UX was really bad. The ongoing transfers and even new ones of the pending sync needed to get executed before the sync was really removed. Now, the sync is removed "instantly" from the UI, the sync is stopped asynchronously and no new events will get in.

(The tests should be clear about what went wrong in background and the "instantly" ui stuff was resolved by starting a non-ui thread)