### PR TITLE
fixed master; fixed tests for Fake [InMemoryDropMessageRepository]

### DIFF
--- a/src/test-gui/java/de/qabel/desktop/ui/AbstractControllerGUITest.java
+++ b/src/test-gui/java/de/qabel/desktop/ui/AbstractControllerGUITest.java
@@ -25,14 +25,14 @@ public class AbstractControllerGUITest extends AbstractGuiTest<AlertTestControll
         try {
             runLaterAndWait(alert.getAlert().getDialogPane()::requestFocus);
             waitTillTheEnd(alert.getAlert().getDialogPane());
-            assertEquals("Error", alert.getAlert().getTitle());
-            assertEquals("some error message", alert.getAlert().getHeaderText());
-            assertEquals(Alert.AlertType.ERROR, alert.getAlert().getAlertType());
-            assertEquals("exceptionmessage", alert.getExceptionLabel().getText());
+            CrashReportAlertPage page = new CrashReportAlertPage(baseFXRobot, robot, alert);
 
-            clickOn(".feedback").write("123456");
-            clickOn(".send");
-            waitUntil(alert.getInputArea().getText()::isEmpty);
+            assertEquals("Error", page.getTitle());
+            assertEquals("some error message", page.getHeaderText());
+            assertEquals(Alert.AlertType.ERROR, page.getType());
+            assertEquals("exceptionmessage", page.getExceptionLabel());
+
+            page.setFeedback("123456").send();
             assertEquals("123456", crashReportHandler.text);
             assertNotNull(crashReportHandler.stacktrace);
         } finally {

--- a/src/test-gui/java/de/qabel/desktop/ui/CrashReportAlertPage.java
+++ b/src/test-gui/java/de/qabel/desktop/ui/CrashReportAlertPage.java
@@ -1,0 +1,41 @@
+package de.qabel.desktop.ui;
+
+import com.sun.javafx.robot.FXRobot;
+import javafx.scene.control.Alert;
+import org.testfx.api.FxRobot;
+
+public class CrashReportAlertPage extends AbstractPage {
+    private CrashReportAlert alert;
+
+    public CrashReportAlertPage(FXRobot baseFXRobot, FxRobot robot, CrashReportAlert alert) {
+        super(baseFXRobot, robot);
+        this.alert = alert;
+    }
+
+    public String getTitle() {
+        return alert.getAlert().getTitle();
+    }
+
+    public String getHeaderText() {
+        return alert.getAlert().getHeaderText();
+    }
+
+    public Alert.AlertType getType() {
+        return alert.getAlert().getAlertType();
+    }
+
+    public String getExceptionLabel() {
+        return alert.getExceptionLabel().getText();
+    }
+
+    public CrashReportAlertPage setFeedback(String message) {
+        clickOn(".feedback").write(message);
+        return this;
+    }
+
+    public CrashReportAlertPage send() {
+        clickOn(".send");
+        waitUntil(() -> alert.getInputArea().getText().isEmpty());
+        return this;
+    }
+}

--- a/src/test/java/de/qabel/desktop/repository/inmemory/InMemoryContactRepository.java
+++ b/src/test/java/de/qabel/desktop/repository/inmemory/InMemoryContactRepository.java
@@ -1,4 +1,4 @@
-package de.qabel.desktop.repository.Stub;
+package de.qabel.desktop.repository.inmemory;
 
 import de.qabel.core.config.Contact;
 import de.qabel.core.config.Contacts;

--- a/src/test/java/de/qabel/desktop/repository/inmemory/InMemoryDropMessageRepository.java
+++ b/src/test/java/de/qabel/desktop/repository/inmemory/InMemoryDropMessageRepository.java
@@ -1,4 +1,4 @@
-package de.qabel.desktop.repository.Stub;
+package de.qabel.desktop.repository.inmemory;
 
 import de.qabel.core.config.Contact;
 import de.qabel.core.config.Entity;
@@ -10,7 +10,7 @@ import de.qabel.desktop.ui.actionlog.PersistenceDropMessage;
 
 import java.util.*;
 
-public class StubDropMessageRepository extends Observable implements DropMessageRepository {
+public class InMemoryDropMessageRepository extends Observable implements DropMessageRepository {
     public PersistenceDropMessage lastMessage;
     private List<PersistenceDropMessage> messages = new LinkedList<>();
 
@@ -23,6 +23,7 @@ public class StubDropMessageRepository extends Observable implements DropMessage
     @Override
     public synchronized void save(PersistenceDropMessage pdm) throws PersistenceException {
         messages.add(pdm);
+        lastMessage = pdm;
         setChanged();
         notifyObservers(pdm);
     }

--- a/src/test/java/de/qabel/desktop/ui/AbstractControllerTest.java
+++ b/src/test/java/de/qabel/desktop/ui/AbstractControllerTest.java
@@ -19,11 +19,10 @@ import de.qabel.desktop.daemon.management.DefaultTransferManager;
 import de.qabel.desktop.daemon.sync.SyncDaemon;
 import de.qabel.desktop.daemon.sync.worker.FakeSyncerFactory;
 import de.qabel.desktop.daemon.sync.worker.index.SyncIndexFactory;
-import de.qabel.desktop.daemon.sync.worker.index.memory.InMemorySyncIndexFactory;
 import de.qabel.desktop.daemon.sync.worker.index.sqlite.SqliteSyncIndexFactory;
 import de.qabel.desktop.repository.*;
-import de.qabel.desktop.repository.Stub.InMemoryContactRepository;
-import de.qabel.desktop.repository.Stub.StubDropMessageRepository;
+import de.qabel.desktop.repository.inmemory.InMemoryContactRepository;
+import de.qabel.desktop.repository.inmemory.InMemoryDropMessageRepository;
 import de.qabel.desktop.repository.inmemory.*;
 import de.qabel.desktop.inject.DefaultServiceFactory;
 import de.qabel.desktop.ui.actionlog.item.renderer.FXMessageRendererFactory;
@@ -38,11 +37,9 @@ import org.apache.logging.slf4j.Log4jLogger;
 import org.junit.After;
 import org.junit.Before;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 import java.util.function.Function;
-import java.util.logging.LogManager;
 
 public class AbstractControllerTest extends AbstractFxTest {
     protected static Logger logger;
@@ -54,7 +51,7 @@ public class AbstractControllerTest extends AbstractFxTest {
     protected ContactRepository contactRepository = new InMemoryContactRepository();
     protected DefaultTransferManager transferManager;
     protected BoxVolumeFactoryStub boxVolumeFactory;
-    protected DropMessageRepository dropMessageRepository = new StubDropMessageRepository();
+    protected DropMessageRepository dropMessageRepository = new InMemoryDropMessageRepository();
     protected DropConnector httpDropConnector = new InMemoryHttpDropConnector();
     protected StubCrashReportHandler crashReportHandler = new StubCrashReportHandler();
     protected SharingService sharingService = new BlockSharingService(dropMessageRepository, httpDropConnector);

--- a/src/test/java/de/qabel/desktop/ui/actionlog/ActionlogControllerTest.java
+++ b/src/test/java/de/qabel/desktop/ui/actionlog/ActionlogControllerTest.java
@@ -6,7 +6,7 @@ import de.qabel.core.config.Identity;
 import de.qabel.core.drop.DropMessage;
 import de.qabel.desktop.daemon.drop.TextMessage;
 import de.qabel.desktop.repository.DropMessageRepository;
-import de.qabel.desktop.repository.Stub.StubDropMessageRepository;
+import de.qabel.desktop.repository.inmemory.InMemoryDropMessageRepository;
 import de.qabel.desktop.ui.AbstractControllerTest;
 import de.qabel.desktop.ui.actionlog.item.MyActionlogItemController;
 import de.qabel.desktop.ui.actionlog.item.MyActionlogItemView;
@@ -28,7 +28,7 @@ public class ActionlogControllerTest extends AbstractControllerTest {
     Contact c;
     String text = "MessageString";
     DropMessage dm;
-    StubDropMessageRepository repo;
+    InMemoryDropMessageRepository repo;
 
     @Test
     public void addMessageToActionlogTest() throws Exception {
@@ -60,14 +60,13 @@ public class ActionlogControllerTest extends AbstractControllerTest {
         i = identityBuilderFactory.factory().withAlias("NewIdentity").build();
         c = new Contact(i.getAlias(), i.getDropUrls(), i.getEcPublicKey());
 
-        String msg2 = "msg2";
-        controller.sendDropMessage(c, msg2);
         clientConfiguration.selectIdentity(i);
+        controller.sendDropMessage(c, "msg2");
 
         List<PersistenceDropMessage> lst = dropMessageRepository.loadConversation(c, i);
 
         assertEquals(1, lst.size());
-        assertEquals(msg2, TextMessage.fromJson(lst.get(0).dropMessage.getDropPayload()).getText());
+        assertEquals("msg2", TextMessage.fromJson(lst.get(0).dropMessage.getDropPayload()).getText());
     }
 
     @Test
@@ -102,7 +101,7 @@ public class ActionlogControllerTest extends AbstractControllerTest {
     @Override
     @Before
     public void setUp() throws Exception {
-        repo = new StubDropMessageRepository();
+        repo = new InMemoryDropMessageRepository();
         dropMessageRepository = repo;
         super.setUp();
         i = identityBuilderFactory.factory().withAlias("TestAlias").build();

--- a/src/test/java/de/qabel/desktop/ui/actionlog/ActionlogTest.java
+++ b/src/test/java/de/qabel/desktop/ui/actionlog/ActionlogTest.java
@@ -3,7 +3,7 @@ package de.qabel.desktop.ui.actionlog;
 import de.qabel.core.config.Contact;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.drop.DropMessage;
-import de.qabel.desktop.repository.Stub.StubDropMessageRepository;
+import de.qabel.desktop.repository.inmemory.InMemoryDropMessageRepository;
 import de.qabel.desktop.ui.AbstractControllerTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,7 +14,7 @@ import java.util.List;
 import static org.junit.Assert.*;
 
 public class ActionlogTest extends AbstractControllerTest {
-    private StubDropMessageRepository repo = new StubDropMessageRepository();
+    private InMemoryDropMessageRepository repo = new InMemoryDropMessageRepository();
     private Actionlog log;
     private DropMessage msg;
     private Contact contact = new Contact("alias", null, new QblECKeyPair().getPub());

--- a/src/test/java/de/qabel/desktop/ui/actionlog/ContactActionLogTest.java
+++ b/src/test/java/de/qabel/desktop/ui/actionlog/ContactActionLogTest.java
@@ -3,7 +3,7 @@ package de.qabel.desktop.ui.actionlog;
 import de.qabel.core.config.Contact;
 import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.drop.DropMessage;
-import de.qabel.desktop.repository.Stub.StubDropMessageRepository;
+import de.qabel.desktop.repository.inmemory.InMemoryDropMessageRepository;
 import de.qabel.desktop.ui.AbstractControllerTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,11 +11,14 @@ import org.junit.Test;
 import java.util.LinkedList;
 import java.util.List;
 
+import static de.qabel.desktop.AsyncUtils.assertAsync;
 import static de.qabel.desktop.AsyncUtils.waitUntil;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
 public class ContactActionLogTest extends AbstractControllerTest {
-    private StubDropMessageRepository repo = new StubDropMessageRepository();
+    private InMemoryDropMessageRepository repo = new InMemoryDropMessageRepository();
     private Actionlog log;
     private DropMessage msg;
     private DropMessage otherMsg;
@@ -62,11 +65,11 @@ public class ContactActionLogTest extends AbstractControllerTest {
         repo.addMessage(msg, identity, contact, false);
 
         log = new ContactActionLog(identity, contact, repo);
-        assertEquals(1, log.getUnseenMessageCount());
+        assertThat(log.getUnseenMessageCount(), is(1));
         for (PersistenceDropMessage message : repo.loadConversation(contact, identity)) {
             message.setSeen(true);
         }
-        waitUntil(() -> log.getUnseenMessageCount() == 0);
+        assertAsync(log::getUnseenMessageCount, is(0));
     }
 
     @Test
@@ -79,6 +82,6 @@ public class ContactActionLogTest extends AbstractControllerTest {
 
         repo.addMessage(msg, identity, contact, false);
         log = new ContactActionLog(identity, contact, repo);
-        assertEquals(0, log.getUnseenMessageCount());
+        assertThat(log.getUnseenMessageCount(), is(1));
     }
 }

--- a/src/test/java/de/qabel/desktop/ui/contact/ContactControllerTest.java
+++ b/src/test/java/de/qabel/desktop/ui/contact/ContactControllerTest.java
@@ -5,7 +5,7 @@ import de.qabel.core.crypto.QblECKeyPair;
 import de.qabel.core.crypto.QblECPublicKey;
 import de.qabel.core.drop.DropMessage;
 import de.qabel.core.exceptions.QblDropInvalidURL;
-import de.qabel.desktop.repository.Stub.StubDropMessageRepository;
+import de.qabel.desktop.repository.inmemory.InMemoryDropMessageRepository;
 import de.qabel.desktop.repository.exception.EntityNotFoundException;
 import de.qabel.desktop.repository.exception.PersistenceException;
 import de.qabel.desktop.ui.AbstractControllerTest;
@@ -149,7 +149,7 @@ public class ContactControllerTest extends AbstractControllerTest {
         dropMessageRepository.addMessage(new DropMessage(contact, "a", "b"), contact, identity, false);
         waitUntil(() -> controller.contactItems.get(0).getIndicator().isVisible());
 
-        ((StubDropMessageRepository)dropMessageRepository).lastMessage.setSeen(true);
+        ((InMemoryDropMessageRepository)dropMessageRepository).lastMessage.setSeen(true);
         waitUntil(() -> !controller.contactItems.get(0).getIndicator().isVisible());
     }
 


### PR DESCRIPTION
The master is broken.
Reason is that the "old" StubDropMessageRepository is used like a Fake and not a Stub in most tests. Those tests are just wrong (wrong orders, wrong assertions, etc). In the previous commit, I "fixed" the StubDropMessageRepository to work like a real InMemory-Fake (just how it's used in those tests) but the wrong tests now fail.

This PR fixes those tests and renames the Stub to "InMemory" aka Fake to clarify the purpose.
Additionally, I stabalized another GuiTest by intruducing the CrashReportAlertPage to encapsulate gui actions and allow for fake clicks, that hit their target reliably.