### PR TITLE
fixed filebrowser synchronism

### DIFF
--- a/src/main/java/de/qabel/desktop/inject/RuntimeDesktopServiceFactory.java
+++ b/src/main/java/de/qabel/desktop/inject/RuntimeDesktopServiceFactory.java
@@ -18,6 +18,7 @@ import de.qabel.desktop.config.BoxSyncConfig;
 import de.qabel.desktop.config.FilesAbout;
 import de.qabel.desktop.config.factory.BlockBoxVolumeFactory;
 import de.qabel.desktop.config.factory.BoxVolumeFactory;
+import de.qabel.desktop.config.factory.CachedBoxVolumeFactory;
 import de.qabel.desktop.crashReports.CrashReportHandler;
 import de.qabel.desktop.daemon.NetworkStatus;
 import de.qabel.desktop.daemon.drop.DropDaemon;
@@ -149,12 +150,12 @@ public abstract class RuntimeDesktopServiceFactory extends AnnotatedDesktopServi
     @Override
     public synchronized BoxVolumeFactory getBoxVolumeFactory() throws IOException {
         if (boxVolumeFactory == null) {
-            boxVolumeFactory = new BlockBoxVolumeFactory(
+            boxVolumeFactory = new CachedBoxVolumeFactory(new BlockBoxVolumeFactory(
                 getClientConfiguration().getDeviceId().getBytes(),
                 getBoxClient(),
                 getIdentityRepository(),
                 getBlockUri()
-            );
+            ));
         }
         return boxVolumeFactory;
     }

--- a/src/main/java/de/qabel/desktop/ui/actionlog/ActionlogController.java
+++ b/src/main/java/de/qabel/desktop/ui/actionlog/ActionlogController.java
@@ -18,7 +18,6 @@ import de.qabel.desktop.ui.actionlog.item.MyActionlogItemView;
 import de.qabel.desktop.ui.actionlog.item.OtherActionlogItemView;
 import de.qabel.desktop.ui.connector.DropConnector;
 import javafx.application.Platform;
-import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Button;
@@ -26,6 +25,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.input.KeyCode;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import org.controlsfx.control.NotificationPane;
@@ -44,6 +44,9 @@ import static java.lang.Thread.sleep;
 public class ActionlogController extends AbstractController implements Initializable, Observer {
     private static final ExecutorService executor = Executors.newSingleThreadExecutor();
     private static final Logger logger = LoggerFactory.getLogger(ActionlogController.class);
+
+    @FXML
+    public BorderPane chat;
     @FXML
     Button accept;
 


### PR DESCRIPTION
The interruption of https://github.com/Qabel/qabel-core/issues/496 caused a strange bug in the desktop-client.

The bug is so complex that I have already forgotton how to describe it. But it has something to do with the fact that the CachedBoxVolumes and the CachedBoxNavigations expected it's read BoxVolumes and BoxNavigations to return new instances but itself didn't.

This could lead to multiple CachedBoxNavigations wrapped around the same navigation instance, thus not notifiing it's observers because the observer was on another CachedBoxNavigation instance than the change but also not notifying it's observers on `refresh` because the refresh on the navigation instance didn't reveal any change that was already applied... o.O

Now changes on the synced folder show up in the BoxFS browser and changes in the browser are synced...