### PR TITLE
fixes #547 logging on dist

### DIFF
--- a/src/main/java/de/qabel/desktop/DesktopClient.java
+++ b/src/main/java/de/qabel/desktop/DesktopClient.java
@@ -4,6 +4,8 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 
 public class DesktopClient {
@@ -15,6 +17,10 @@ public class DesktopClient {
                 System.exit(-1);
             }
         }
+
+
+        Path qabelConfigRoot = Paths.get(System.getProperty("user.home")).resolve(".qabel");
+        System.setProperty("log.root", qabelConfigRoot.toAbsolutePath().toString());
 
         Kernel kernel = new Kernel(version);
 

--- a/src/main/java/de/qabel/desktop/Kernel.java
+++ b/src/main/java/de/qabel/desktop/Kernel.java
@@ -5,7 +5,6 @@ import com.sun.javafx.application.PlatformImpl;
 import de.qabel.box.storage.AbstractNavigation;
 import de.qabel.chat.repository.sqlite.ChatClientDatabase;
 import de.qabel.core.repository.sqlite.ClientDatabase;
-import de.qabel.core.repository.sqlite.DesktopClientDatabase;
 import de.qabel.core.repository.sqlite.SqliteTransactionManager;
 import de.qabel.desktop.config.LaunchConfig;
 import de.qabel.desktop.inject.DesktopServices;
@@ -72,7 +71,6 @@ public class Kernel {
     }
 
     public void initialize() throws Exception {
-        System.setProperty("log.root", databaseFile.getParent().toAbsolutePath().toString());
         Security.setProperty("networkaddress.cache.ttl",  AWS_RECOMMENDED_DNS_CACHE_TTL);
         AbstractNavigation.DEFAULT_AUTOCOMMIT_DELAY = 2000;
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -3,7 +3,7 @@
 
 <Configuration>
     <Appenders>
-        <RandomAccessFile name="RandomAccessFile" fileName="log/desktop.log" immediateFlush="false" append="false">
+        <RandomAccessFile name="RandomAccessFile"  fileName="${sys:log.root}/log/desktop.log" filePattern="${sys:log.root}/log/desktop.%i.log.gz" immediateFlush="false" append="false">
             <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </RandomAccessFile>
 


### PR DESCRIPTION
The "log.root" property needs to be set before the first logger instance is created.
Since this code was in the Kernel and the Kernel has a static logger that is instantiated before anything else is done, thie property was empty and the logging failed.

Now it is set before any logger is created and thus creates nice logs with working rotation.