### PR TITLE
#531 emoji image renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - extracted three modules
 - #522 new lightweight, TextFlow based chat layout
+- #531 emojiSelector selections show as alias (:alias:) in input
 
 ## 0.10.0-beta.3 [BASELINE]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - changelog
 - #522 links in chat are now clickable
 - #531 emojiSelector for chat
+- #531 emojis get rendered as images in chat
 
 ### Changed
 - extracted three modules

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -124,6 +124,7 @@ dependencies {
     compile 'com.jfoenix:jfoenix:[1.0,2.0['
     compile 'commons-validator:commons-validator:[1.4.0,2.0['
     compile 'com.vdurmont:emoji-java:[3.1.3,4.0['                 //MIT
+    compile 'com.github.thomasnield:rxkotlinfx:0.2.0'             //Apache v2
 
     testCompile 'info.cukes:cucumber-java:[1.2.0,2.0['
     testCompile 'info.cukes:cucumber-junit:[1.2.0,2.0['
@@ -191,6 +192,11 @@ distZip() {
         into baseName + '-' + version + '/lib/'
     }
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+license {
+    header rootProject.file('LICENSE')
+    exclude "**/*"
 }
 
 downloadLicenses {

--- a/client/dependencies.lock
+++ b/client/dependencies.lock
@@ -23,6 +23,10 @@
             "locked": "1.2.2",
             "requested": "[1.2.2,2.0["
         },
+        "com.github.thomasnield:rxkotlinfx": {
+            "locked": "0.2.0",
+            "requested": "0.2.0"
+        },
         "com.github.zafarkhaja:java-semver": {
             "locked": "0.9.0",
             "requested": "0.9.+"
@@ -150,6 +154,10 @@
         "com.github.mfornos:humanize-slim": {
             "locked": "1.2.2",
             "requested": "[1.2.2,2.0["
+        },
+        "com.github.thomasnield:rxkotlinfx": {
+            "locked": "0.2.0",
+            "requested": "0.2.0"
         },
         "com.github.zafarkhaja:java-semver": {
             "locked": "0.9.0",
@@ -279,12 +287,16 @@
             "locked": "1.2.2",
             "requested": "[1.2.2,2.0["
         },
+        "com.github.thomasnield:rxkotlinfx": {
+            "locked": "0.2.0",
+            "requested": "0.2.0"
+        },
         "com.github.zafarkhaja:java-semver": {
             "locked": "0.9.0",
             "requested": "0.9.+"
         },
         "com.google.code.gson:gson": {
-            "locked": "2.7",
+            "locked": "2.8.0",
             "requested": "[2.0,3.0["
         },
         "com.google.zxing:core": {
@@ -406,6 +418,10 @@
         "com.github.mfornos:humanize-slim": {
             "locked": "1.2.2",
             "requested": "[1.2.2,2.0["
+        },
+        "com.github.thomasnield:rxkotlinfx": {
+            "locked": "0.2.0",
+            "requested": "0.2.0"
         },
         "com.github.zafarkhaja:java-semver": {
             "locked": "0.9.0",
@@ -571,6 +587,10 @@
             "locked": "1.2.2",
             "requested": "[1.2.2,2.0["
         },
+        "com.github.thomasnield:rxkotlinfx": {
+            "locked": "0.2.0",
+            "requested": "0.2.0"
+        },
         "com.github.zafarkhaja:java-semver": {
             "locked": "0.9.0",
             "requested": "0.9.+"
@@ -734,6 +754,10 @@
         "com.github.mfornos:humanize-slim": {
             "locked": "1.2.2",
             "requested": "[1.2.2,2.0["
+        },
+        "com.github.thomasnield:rxkotlinfx": {
+            "locked": "0.2.0",
+            "requested": "0.2.0"
         },
         "com.github.zafarkhaja:java-semver": {
             "locked": "0.9.0",

--- a/client/src/main/java/de/qabel/desktop/inject/DesktopServices.java
+++ b/client/src/main/java/de/qabel/desktop/inject/DesktopServices.java
@@ -30,6 +30,7 @@ import de.qabel.desktop.ui.util.FileChooserFactory;
 import de.qabel.desktop.util.Translator;
 import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
+import rx.Scheduler;
 
 import java.io.IOException;
 import java.net.URI;
@@ -152,4 +153,13 @@ public interface DesktopServices {
 
     @Create(name="fileChooserFactory")
     FileChooserFactory getFileChooserFactory();
+
+    @Create(name="fxScheduler")
+    Scheduler getFxScheduler();
+
+    @Create(name="ioScheduler")
+    Scheduler getIoScheduler();
+
+    @Create(name="computationScheduler")
+    Scheduler getComputationScheduler();
 }

--- a/client/src/main/java/de/qabel/desktop/inject/RuntimeDesktopServiceFactory.java
+++ b/client/src/main/java/de/qabel/desktop/inject/RuntimeDesktopServiceFactory.java
@@ -45,6 +45,9 @@ import javafx.collections.ObservableList;
 import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
 import org.apache.http.impl.client.HttpClients;
+import rx.Scheduler;
+import rx.schedulers.JavaFxScheduler;
+import rx.schedulers.Schedulers;
 
 import java.io.File;
 import java.io.IOException;
@@ -273,4 +276,18 @@ public abstract class RuntimeDesktopServiceFactory extends AnnotatedDesktopServi
         return runtimeConfiguration.getCurrentVersion();
     }
 
+    @Override
+    public Scheduler getFxScheduler() {
+        return JavaFxScheduler.getInstance();
+    }
+
+    @Override
+    public Scheduler getIoScheduler() {
+        return Schedulers.io();
+    }
+
+    @Override
+    public Scheduler getComputationScheduler() {
+        return Schedulers.computation();
+    }
 }

--- a/client/src/main/java/de/qabel/desktop/ui/actionlog/ActionlogController.java
+++ b/client/src/main/java/de/qabel/desktop/ui/actionlog/ActionlogController.java
@@ -36,8 +36,8 @@ import org.controlsfx.control.NotificationPane;
 import org.controlsfx.control.PopOver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import rx.Scheduler;
 import rx.Subscription;
-import rx.schedulers.JavaFxScheduler;
 
 import javax.inject.Inject;
 import java.net.URL;
@@ -92,6 +92,9 @@ public class ActionlogController extends AbstractController implements Initializ
     private DropMessageRepository dropMessageRepository;
     @Inject
     DropConnector dropConnector;
+
+    @Inject
+    Scheduler fxScheduler;
 
     Identity identity;
     Contact contact;
@@ -344,7 +347,7 @@ public class ActionlogController extends AbstractController implements Initializ
         popOver.show(this.emojiSelector);
 
         Subscription subscription = emojiSelector.onSelect()
-            .subscribeOn(JavaFxScheduler.getInstance())
+            .subscribeOn(fxScheduler)
             .subscribe(emoji -> {
                 insert(" :" + emoji.getAliases().get(0) + ": ");
                 textarea.requestFocus();

--- a/client/src/main/java/de/qabel/desktop/ui/actionlog/ActionlogController.java
+++ b/client/src/main/java/de/qabel/desktop/ui/actionlog/ActionlogController.java
@@ -37,6 +37,7 @@ import org.controlsfx.control.PopOver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Subscription;
+import rx.schedulers.JavaFxScheduler;
 
 import javax.inject.Inject;
 import java.net.URL;
@@ -338,14 +339,17 @@ public class ActionlogController extends AbstractController implements Initializ
         popOver.getStyleClass().add("emojiSelector");
         EmojiSelector emojiSelector = new EmojiSelector();
         emojiSelector.getStylesheets().add(QabelFXMLView.getGlobalStyleSheet());
-        Subscription subscription = emojiSelector.onSelect().subscribe(emoji -> Platform.runLater(() -> {
-            insert(" :" + emoji.getAliases().get(0) + ": ");
-            textarea.requestFocus();
-            popOver.hide();
-        }));
-        popOver.setOnCloseRequest(event -> subscription.unsubscribe());
         popOver.setArrowLocation(PopOver.ArrowLocation.BOTTOM_RIGHT);
         popOver.setContentNode(emojiSelector);
         popOver.show(this.emojiSelector);
+
+        Subscription subscription = emojiSelector.onSelect()
+            .subscribeOn(JavaFxScheduler.getInstance())
+            .subscribe(emoji -> {
+                insert(" :" + emoji.getAliases().get(0) + ": ");
+                textarea.requestFocus();
+                popOver.hide();
+            });
+        popOver.setOnCloseRequest(event -> subscription.unsubscribe());
     }
 }

--- a/client/src/main/java/de/qabel/desktop/ui/actionlog/ActionlogController.java
+++ b/client/src/main/java/de/qabel/desktop/ui/actionlog/ActionlogController.java
@@ -1,6 +1,7 @@
 package de.qabel.desktop.ui.actionlog;
 
 import com.airhacks.afterburner.views.QabelFXMLView;
+import com.vdurmont.emoji.EmojiParser;
 import de.qabel.core.config.Contact;
 import de.qabel.core.config.Entity;
 import de.qabel.core.config.Identity;
@@ -162,6 +163,7 @@ public class ActionlogController extends AbstractController implements Initializ
     }
 
     void sendDropMessage(Contact c, String text) throws QblDropPayloadSizeException, QblNetworkInvalidResponseException, PersistenceException {
+        text = EmojiParser.parseToUnicode(text);
         DropMessage d = new DropMessage(identity, new TextMessage(text).toJson(), DropMessageRepository.PAYLOAD_TYPE_MESSAGE);
         d.setDropMessageMetadata(new DropMessageMetadata(identity));
         dropConnector.send(c, d);

--- a/client/src/main/java/de/qabel/desktop/ui/actionlog/ActionlogController.java
+++ b/client/src/main/java/de/qabel/desktop/ui/actionlog/ActionlogController.java
@@ -336,13 +336,11 @@ public class ActionlogController extends AbstractController implements Initializ
         popOver.getStyleClass().add("emojiSelector");
         EmojiSelector emojiSelector = new EmojiSelector();
         emojiSelector.getStylesheets().add(QabelFXMLView.getGlobalStyleSheet());
-        Subscription subscription = emojiSelector.onSelect().subscribe(emoji -> {
-            Platform.runLater(() -> {
-                insert(emoji.getUnicode());
-                textarea.requestFocus();
-                popOver.hide();
-            });
-        });
+        Subscription subscription = emojiSelector.onSelect().subscribe(emoji -> Platform.runLater(() -> {
+            insert(" :" + emoji.getAliases().get(0) + ": ");
+            textarea.requestFocus();
+            popOver.hide();
+        }));
         popOver.setOnCloseRequest(event -> subscription.unsubscribe());
         popOver.setArrowLocation(PopOver.ArrowLocation.BOTTOM_RIGHT);
         popOver.setContentNode(emojiSelector);

--- a/client/src/main/java/de/qabel/desktop/ui/actionlog/emoji/EmojiGridCell.java
+++ b/client/src/main/java/de/qabel/desktop/ui/actionlog/emoji/EmojiGridCell.java
@@ -37,11 +37,9 @@ public class EmojiGridCell extends GridCell<Emoji> {
     }
 
     private void loadEmojiImage(Emoji emoji) {
-        String emojiCode = emoji.getHtmlHexadecimal().replace(";&#x", "_").replace(";", "").replace("&#x", "");
-        String filename = "/icon/emoji/emoji_" + emojiCode + (emoji.supportsFitzpatrick() ? "_1f3fb" : "") + ".png";
         setOnMouseClicked(event -> emojiSelect.onNext(emoji));
         int width = getWidth() == 0 ? 25 : (int) getWidth();
-        ImageView icon = Icons.getIcon(filename, width);
+        ImageView icon = Icons.getIcon(emoji, width);
         icon.fitWidthProperty().bind(widthProperty());
         setGraphic(icon);
     }

--- a/client/src/main/java/de/qabel/desktop/ui/actionlog/item/renderer/PlaintextMessageRenderer.java
+++ b/client/src/main/java/de/qabel/desktop/ui/actionlog/item/renderer/PlaintextMessageRenderer.java
@@ -1,6 +1,7 @@
 package de.qabel.desktop.ui.actionlog.item.renderer;
 
 import de.qabel.desktop.daemon.drop.TextMessage;
+import de.qabel.desktop.ui.actionlog.item.renderer.partial.EmojiRenderer;
 import de.qabel.desktop.ui.actionlog.item.renderer.partial.HyperlinkRenderer;
 import de.qabel.desktop.ui.actionlog.item.renderer.partial.PartialFXMessageRenderer;
 import javafx.scene.Node;
@@ -13,7 +14,13 @@ import java.util.List;
 import java.util.ResourceBundle;
 
 public class PlaintextMessageRenderer implements FXMessageRenderer {
+    private final List<PartialFXMessageRenderer> partialRenderers = new LinkedList<>();
     private final HyperlinkRenderer hyperlinkRenderer = new HyperlinkRenderer();
+
+    public PlaintextMessageRenderer() {
+        partialRenderers.add(hyperlinkRenderer);
+        partialRenderers.add(new EmojiRenderer());
+    }
 
     @Override
     public TextFlow render(String prefixAlias, String dropPayload, ResourceBundle resourceBundle) {
@@ -34,9 +41,6 @@ public class PlaintextMessageRenderer implements FXMessageRenderer {
     }
 
     private void replaceRenderableChildren(List<Node> children) {
-        List<PartialFXMessageRenderer> partialRenderers = new LinkedList<>();
-        partialRenderers.add(hyperlinkRenderer);
-
         int size;
         do {
             size = children.size();

--- a/client/src/main/java/de/qabel/desktop/ui/actionlog/item/renderer/partial/EmojiRenderer.java
+++ b/client/src/main/java/de/qabel/desktop/ui/actionlog/item/renderer/partial/EmojiRenderer.java
@@ -1,0 +1,46 @@
+package de.qabel.desktop.ui.actionlog.item.renderer.partial;
+
+import com.vdurmont.emoji.EmojiManager;
+import com.vdurmont.emoji.EmojiParser;
+import de.qabel.desktop.ui.util.Icons;
+import javafx.geometry.Insets;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.image.ImageView;
+import javafx.scene.text.Text;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class EmojiRenderer extends AbstractPatternExtractionRenderer {
+    private static final Pattern ALIAS_PATTERN = Pattern.compile("(:(\\w|\\||\\-)+:)");
+
+    @Override
+    public boolean needsFormatting(String text) {
+        return super.needsFormatting(EmojiParser.parseToAliases(text));
+    }
+
+    @Override
+    protected Pattern getPattern() {
+        return ALIAS_PATTERN;
+    }
+
+    @Override
+    public List<Node> render(String text) {
+        return super.render(EmojiParser.parseToAliases(text));
+    }
+
+    @Override
+    protected Node replace(String match, Matcher matcher) {
+        if (!match.startsWith(":") || !match.endsWith(":")) {
+            return new Text(match);
+        }
+        ImageView icon = Icons.getIcon(EmojiManager.getForAlias(match), 24);
+        icon.getStyleClass().add("emoji");
+        Label emojiLabel = new Label("", icon);
+        emojiLabel.getStyleClass().add("emoji-container");
+        emojiLabel.setPadding(new Insets(0, 1, 0, 1));
+        return emojiLabel;
+    }
+}

--- a/client/src/main/java/de/qabel/desktop/ui/util/Icons.java
+++ b/client/src/main/java/de/qabel/desktop/ui/util/Icons.java
@@ -1,5 +1,6 @@
 package de.qabel.desktop.ui.util;
 
+import com.vdurmont.emoji.Emoji;
 import de.codecentric.centerdevice.javafxsvg.SvgImageLoaderFactory;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -22,6 +23,7 @@ public class Icons {
     public static final String FOLDER = "/svg/ic_folder_black_24px.svg";
     public static final String FILE = "/svg/ic_folder_black_24px.svg";
     private static final Map<String, ImageView> imageCache = Collections.synchronizedMap(new HashMap<>());
+    private static final Map<Emoji, String> emojiCache = Collections.synchronizedMap(new HashMap<>());
 
     public static final int LARGE_ICON_WIDTH = 32;
 
@@ -62,5 +64,21 @@ public class Icons {
 
     public static Image getImage(String path) {
         return new Image(Icons.class.getResourceAsStream(path));
+    }
+
+    public static ImageView getIcon(Emoji emoji) {
+        return getIcon(emoji, LARGE_ICON_WIDTH);
+    }
+
+    public static ImageView getIcon(Emoji emoji, int width) {
+        synchronized (emojiCache) {
+            if (!emojiCache.containsKey(emoji)) {
+                String emojiCode = emoji.getHtmlHexadecimal().replace(";&#x", "_").replace(";", "").replace("&#x", "");
+                String path = "/icon/emoji/emoji_" + emojiCode + (emoji.supportsFitzpatrick() ? "_1f3fb" : "") + ".png";
+                emojiCache.put(emoji, path);
+            }
+        }
+
+        return getIcon(emojiCache.get(emoji), width);
     }
 }

--- a/client/src/main/resources/main.css
+++ b/client/src/main/resources/main.css
@@ -276,6 +276,9 @@
 .message-text {
     -fx-text-fill: #222222;
 }
+.message-text > * > * {
+    -fx-font-size: 15px;
+}
 .message-text .hyperlink  {
     -fx-fill: #ff690f;
     -fx-text-fill: #ff690f;
@@ -303,6 +306,7 @@
     -fx-min-width: 2em;
     -fx-pref-height: 1em;
     -fx-padding: 2px 0 0 0;
+    -fx-translate-y: 1px;
 }
 .message.sequence .message-date {
     -fx-text-fill: #CCCCCC;

--- a/client/src/test/java/de/qabel/desktop/ui/AbstractControllerTest.java
+++ b/client/src/test/java/de/qabel/desktop/ui/AbstractControllerTest.java
@@ -50,6 +50,8 @@ import org.apache.logging.slf4j.Log4jLogger;
 import org.junit.After;
 import org.junit.Before;
 import org.slf4j.Logger;
+import rx.schedulers.JavaFxScheduler;
+import rx.schedulers.Schedulers;
 
 import java.net.URI;
 import java.util.Locale;
@@ -167,6 +169,10 @@ public class AbstractControllerTest extends AbstractFxTest {
         syncDaemon = new SyncDaemon(new SimpleListProperty<>(), new FakeSyncerFactory());
         diContainer.put("syncDaemon", syncDaemon);
         diContainer.put("accountingUri", new URI("http://localhost:9696"));
+
+        diContainer.put("fxScheduler", JavaFxScheduler.getInstance());
+        diContainer.put("ioScheduler", Schedulers.immediate());
+        diContainer.put("computationScheduler", Schedulers.immediate());
 
         AfterburnerInjector.setConfigurationSource(key -> diContainer.get((String) key));
         AfterburnerInjector.setInstanceSupplier(new RecursiveInjectionInstanceSupplier(diContainer));

--- a/client/src/test/java/de/qabel/desktop/ui/actionlog/ActionlogControllerTest.java
+++ b/client/src/test/java/de/qabel/desktop/ui/actionlog/ActionlogControllerTest.java
@@ -132,6 +132,15 @@ public class ActionlogControllerTest extends AbstractControllerTest {
     }
 
     @Test
+    public void convertsEmojiAliasesToUnicode() throws Exception {
+        controller.sendDropMessage(c, "contains :smiley:");
+
+        List<PersistenceDropMessage> lst = dropMessageRepository.loadConversation(c, i);
+        String message = TextMessage.fromJson(lst.get(0).dropMessage.getDropPayload()).getText();
+        assertEquals("contains \uD83D\uDE03", message);
+    }
+
+    @Test
     public void refreshTime() throws Exception {
         controller.sleepTime = 1;
         controller.dateRefresher.interrupt();

--- a/client/src/test/java/de/qabel/desktop/ui/actionlog/item/renderer/partial/EmojiRendererTest.java
+++ b/client/src/test/java/de/qabel/desktop/ui/actionlog/item/renderer/partial/EmojiRendererTest.java
@@ -1,0 +1,53 @@
+package de.qabel.desktop.ui.actionlog.item.renderer.partial;
+
+import com.vdurmont.emoji.EmojiManager;
+import de.qabel.desktop.ui.AbstractFxTest;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.image.ImageView;
+import javafx.scene.text.Text;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class EmojiRendererTest extends AbstractFxTest {
+    public static final String EMOJI = EmojiManager.getForAlias("smiley").getUnicode();
+    private EmojiRenderer emojiRenderer = new EmojiRenderer();
+
+    @Test
+    public void rendersSingleEmoji() {
+        List<Node> nodes = emojiRenderer.render(EMOJI);
+        assertEquals(1, nodes.size());
+        ImageView image = assertImageView(nodes.get(0));
+
+        assertTrue(image.getStyleClass().contains("emoji"));
+        assertEquals(24, image.getFitWidth(), 0.001);
+    }
+
+    private ImageView assertImageView(Node actual) {
+        assertThat(actual, instanceOf(Label.class));
+        Node imageView = ((Label) actual).getGraphic();
+        assertThat(imageView, instanceOf(ImageView.class));
+        return (ImageView)imageView;
+    }
+
+
+    private void assertText(Node actual) {
+        assertThat(actual, instanceOf(Text.class));
+    }
+
+    @Test
+    public void rendersEmojiTextSequence() {
+        List<Node> nodes = emojiRenderer.render("text with " + EMOJI + " and another " + EMOJI);
+        assertEquals(4, nodes.size());
+        assertText(nodes.get(0));
+        assertImageView(nodes.get(1));
+        assertText(nodes.get(2));
+        assertImageView(nodes.get(3));
+    }
+}

--- a/guiTest/build.gradle
+++ b/guiTest/build.gradle
@@ -42,3 +42,9 @@ tasks.withType(Test) {
 run {
     systemProperty 'java.library.path', 'libs/'
 }
+
+test {
+    testLogging {
+        events 'started'
+    }
+}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/3258762/19823371/7d95ce8a-9d68-11e6-95c4-76f9fa927f37.png)

As the source images for the emojis are 48px per dimension, they are now shown as 24px in the chat to let every pixel look good enough. For other sizes to look good we would have to get svg images or resize the source files. I adjusted the font size to fit to that (it was too small anyways).

`xxx :D xxx` is rendered as `TextFlow(Text("xxx"),  Label(ImageView(...)), Text("xxx")). Without the label, the TextFlow would ignore all positioning of the image and align it to the text baseline (which would render too high). Inside the label, we can show the image centered in all dimensions.

select emoji image -> :alias: is inserted to input -> :alias: is converted to unicode before being sent -> unicode emoji is replaced by image in the chat message view