### PR TITLE
Create new image views for each row

### DIFF
--- a/client/src/main/java/de/qabel/desktop/ui/remotefs/RemoteFSController.java
+++ b/client/src/main/java/de/qabel/desktop/ui/remotefs/RemoteFSController.java
@@ -75,8 +75,6 @@ public class RemoteFSController extends AbstractController implements Initializa
     private static Image uploadFolderImage = optionImage("/icon/folder-upload.png");
     private static Image downloadImage = optionImage("/icon/download.png");
     private static Image addFolderImage = optionImage("/icon/add_folder.png");
-    private static ImageView deleteImage = Icons.getIcon(Icons.DELETE, OPTION_EDGE_SIZE);
-    private static ImageView shareImage = Icons.getIcon(SHARE, OPTION_EDGE_SIZE);
     private FakeBoxObject shareObject;
 
     private static Image optionImage(String resourcePath) {
@@ -313,6 +311,8 @@ public class RemoteFSController extends AbstractController implements Initializa
     private void loadInlineButtons(TreeItem<BoxObject> item, HBox bar) {
         bar.getChildren().clear();
         buttonFromImage(item, bar, downloadImage, this::download, "download");
+        ImageView deleteImage = Icons.getIcon(Icons.DELETE, OPTION_EDGE_SIZE);
+        ImageView shareImage = Icons.getIcon(SHARE, OPTION_EDGE_SIZE);
 
         if (item.getValue() instanceof BoxFolder) {
             buttonFromImage(item, bar, uploadFileImage, this::uploadFile, "upload_file");


### PR DESCRIPTION
Otherwise all rows use the same imageview which
only renders _once_, in the last row.
The gui-test did not pick this one up because it
only checks if the view is visible, but not _where_.

Regression tests are missing because I don't know  #how.

Fixes #571